### PR TITLE
To build the aggregator jar

### DIFF
--- a/examples/aggregator/pom.xml
+++ b/examples/aggregator/pom.xml
@@ -61,6 +61,28 @@
 
     <build>
         <finalName>sample_xgboost_apps-${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <!-- put your configurations here -->
+                    <artifactSet>
+                        <includes>
+                            <include>com.nvidia:spark_examples_*</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
Maven shade plugin to aggregate sample app jars(utils/taxi/mortgage/agaricus) into the `sample_xgboost_apps-${project.version}.jar`