### PR TITLE
Update PCA related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repo for all spark examples using Rapids Accelerator including ETL, ML/DL, etc.
 
-It includes docs and example applications that demonstrate the RAPIDS.ai GPU-accelerated XGBoost-Spark project. It now supports Spark 3.0.0+
+It includes docs and example applications that demonstrate the RAPIDS.ai GPU-accelerated XGBoost-Spark and Spark-ML(PCA Algorithm) projects. It now supports Spark 3.0.0+.
 
 ## Examples
 
@@ -11,6 +11,8 @@ It includes docs and example applications that demonstrate the RAPIDS.ai GPU-acc
 - Mortgage: [Scala](/examples/mortgage/scala/src/com/nvidia/spark/examples/mortgage), [Python](/examples/mortgage/python/com/nvidia/spark/examples/mortgage)
 - Taxi: [Scala](/examples/taxi/scala/src/com/nvidia/spark/examples/taxi), [Python](/examples/taxi/python/com/nvidia/spark/examples/taxi)
 - Agaricus: [Scala](/examples/agaricus/scala/src/com/nvidia/spark/examples/agaricus), [Python](/examples/agaricus/python/com/nvidia/spark/examples/agaricus)
+### 2. Spark-ML examples
+- PCA: [Scala](/examples/pca)
 
 ### 2. TensorFlow training on Horovod Spark example
 
@@ -53,6 +55,9 @@ or [Python](/examples/app-parameters/supported_xgboost_parameters_python.md)
 ### 2. TensorFlow training on Horovod Spark example guide
 
 Please follow the README guide here: [README](examples/criteo_train/README.md)
+
+### 3. PCA example guide
+Please follow the README guide here: [README](/examples/pca/README.md)
 
 ## API
 ### 1. Xgboost examples API

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ It includes docs and example applications that demonstrate the RAPIDS.ai GPU-acc
 - Mortgage: [Scala](/examples/mortgage/scala/src/com/nvidia/spark/examples/mortgage), [Python](/examples/mortgage/python/com/nvidia/spark/examples/mortgage)
 - Taxi: [Scala](/examples/taxi/scala/src/com/nvidia/spark/examples/taxi), [Python](/examples/taxi/python/com/nvidia/spark/examples/taxi)
 - Agaricus: [Scala](/examples/agaricus/scala/src/com/nvidia/spark/examples/agaricus), [Python](/examples/agaricus/python/com/nvidia/spark/examples/agaricus)
-### 2. Spark-ML examples
-- PCA: [Scala](/examples/pca)
 
 ### 2. TensorFlow training on Horovod Spark example
 
 - Criteo: [Python](/examples/criteo_train/criteo_keras.py)
+
+### 3. Spark-ML examples
+- PCA: [Scala](/examples/pca)
 
 ## Getting Started Guides
 

--- a/examples/pca/README.md
+++ b/examples/pca/README.md
@@ -6,6 +6,15 @@ This is an example of the GPU accelerated PCA algorithm running on Spark.
 
 Please refer to [README](https://github.com/NVIDIA/spark-rapids-ml#readme) in the [spark-rapids-ml](https://github.com/NVIDIA/spark-rapids-ml) github repository for build instructions and API usage.
 
+## Get jars from Maven Central
+
+User can also download the release jar from Maven central. Due to incompatible cuda libraries, we provide 2 jars for different cuda environments:
+
+For `cuda11.0` : [rapids-4-spark-ml_2.12-21.10.0-cuda11.jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-ml_2.12/21.10.0/rapids-4-spark-ml_2.12-21.10.0-cuda11.jar)
+
+For `cuda11.1` to `cuda11.4` : [rapids-4-spark-ml_2.12-21.10.0-cuda11-2.jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-ml_2.12/21.10.0/rapids-4-spark-ml_2.12-21.10.0-cuda11-2.jar)
+
+
 ## Sample code
 
 User can find sample scala code in [`main.scala`](./main.scala). In the sample code, we will generate random data with 2048 feature dimensions. Then we use PCA to reduce number of features to 3.


### PR DESCRIPTION
Update documents for upcoming 21.10 release. 
related to: https://github.com/NVIDIA/spark-rapids-ml/issues/8

Note, the jar links are not available until jars are officially released. 
Better to merge after release.

Signed-off-by: Allen Xu <allxu@nvidia.com>