### PR TITLE
Add YARN Device Plugin to support MIG GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repo for Spark related utilities and examples using the Rapids Accelerator,including ETL, ML/DL, etc.
 
-It include utilities related to running Spark using the Rapids Accelerator, docs and example applications that
+It includes utilities related to running Spark using the Rapids Accelerator, docs and example applications that
 demonstrate the RAPIDS.ai GPU-accelerated Spark and Spark-ML(PCA Algorithm) projects.
 It now supports Spark 3.0.0+.  It is recommended to set up Spark Cluster with JDK8.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A repo for Spark related utilities and examples using the Rapids Accelerator,inc
 
 It includes utilities related to running Spark using the Rapids Accelerator, docs and example applications that
 demonstrate the RAPIDS.ai GPU-accelerated Spark and Spark-ML(PCA Algorithm) projects.
-It now supports Spark 3.0.0+.  It is recommended to set up Spark Cluster with JDK8.
+Please see the [Rapids Accelerator for Spark documentation](https://nvidia.github.io/spark-rapids/Getting-Started/) for supported
+Spark versions and requirements. It is recommended to set up Spark Cluster with JDK8.
 
 ## Utilities and Examples
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # spark-rapids-examples
 
-A repo for all spark examples using Rapids Accelerator including ETL, ML/DL, etc.
+A repo for Spark related utilities and examples using the Rapids Accelerator,including ETL, ML/DL, etc.
 
-It includes docs and example applications that demonstrate the RAPIDS.ai GPU-accelerated XGBoost-Spark and Spark-ML(PCA Algorithm) projects. It now supports Spark 3.0.0+.
-It is recommended to set up Spark Cluster with JDK8.
+It include utilities related to running Spark using the Rapids Accelerator, docs and example applications that
+demonstrate the RAPIDS.ai GPU-accelerated Spark and Spark-ML(PCA Algorithm) projects.
+It now supports Spark 3.0.0+.  It is recommended to set up Spark Cluster with JDK8.
 
-## Examples
+## Utilities and Examples
 
 ### 1. Xgboost examples
 
@@ -24,6 +25,9 @@ It is recommended to set up Spark Cluster with JDK8.
 
 ### 4. Spark-ML examples
 - PCA: [Scala](/examples/pca)
+
+### 5. NVIDIA GPU Plugin for YARN with MIG support
+- [YARN MIG GPU Plugin](hadoop/device-plugins/gpu-mig)
 
 ## Getting Started Guides
 

--- a/hadoop/device-plugins/gpu-mig/README.md
+++ b/hadoop/device-plugins/gpu-mig/README.md
@@ -1,0 +1,106 @@
+# NVIDIA GPU Plugin for YARN with MIG support
+
+This Plugin adds support for GPU's with [MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) on YARN. The built-in YARN GPU plugin does not support MIG enabled GPUs.
+This Plugin also works with GPUs without MIG or GPUs with MIG disabled but the limitation section still applies. It supports heterogenous environments where
+there may be some MIG enabled GPUs and some without MIG. If you are not using MIG enabled GPUs, you should use the built-in YARN GPU plugin.
+
+## Compatibility
+
+It works with Apache YARN 3.3.0+ versions that support the [Pluggable Device Framework](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/PluggableDeviceFramework.html). This plugin requires YARN to be configured with cgroups and Nvidia Docker runtime v2.
+
+## Limitations
+
+Please see the [MIG Application Considerations](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#app-considerations)
+and [CUDA Device Enumeration](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#cuda-visible-devices).
+
+Its important to note the with CUDA 11, only enumeration of a single MIG instance is supported, limitation. This means that this plugin
+only supports 1 GPU per container and the plugin will throw an exception by default if you request more.
+It is recommended that you configure YARN to only allow a single GPU be requested. See the yarn config:
+```
+ yarn.resource-types.nvidia/miggpu.maximum-allocation
+```
+See [YARN Resource Configuration](https://hadoop.apache.org/docs/r3.3.1/hadoop-yarn/hadoop-yarn-site/ResourceModel.html) for more details.
+If you do not configure the maximum allocation and someone requests multiple GPUs, the default behavior is to throw an exception and the user
+visible exception is not very useful, the real exception will be in the nodemanager logs. See the [Configuration](#configuration) section for options on
+if it throws an exception.
+
+## Building From Source
+
+```
+mvn package 
+```
+
+This will create a jar `target/yarn-gpu-mig-plugin-1.0.0.jar`. This jar can be installed on your YARN cluster as a plugin.
+
+## Installation
+
+Assumes YARN is already installed and configured with cgroups enabled and Nvidia Docker runtime v2.
+Enable and configure your [GPUs with MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html) on all of the nodes it applies to.
+
+Install the jar into your Hadoop Cluster, see the [Test and Use Your Own Plugin](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/DevelopYourOwnDevicePlugin.html)
+section. This recommends installing it in something like `$HADOOP_COMMOND_HOME/share/hadoop/yarn`.
+
+Configure the device plugin, see the YARN documentation on [Pluggable Device Framework](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/PluggableDeviceFramework.html).
+
+After enabling the framework, enable the plugin in `yarn-site.xml`:
+
+```
+<property>
+  <name>yarn.nodemanager.pluggable-device-framework.device-classes</name>
+  <value>com.nvidia.spark.NvidiaGPUMigPluginForRuntimeV2</value>
+</property>
+
+```
+
+Configure YARN to have the new resource type by modifying the `resource-types.xml` file to include:
+
+```
+<property>
+  <name>yarn.resource-types</name>
+  <value>nvidia/miggpu</value>
+</property>
+```
+
+Restart YARN to pick up any configuration changes.
+
+## Configuration
+
+To change the behavior of throwing when the user allocates multiple GPUs you can either set a config in the `yarn-site.xml` or set
+an environment variable when launching the Spark application. In either case, `true` means to throw if a user requests multiple
+GPUs(this is the default), `false` means it won't throw and if the container is allocated with multiple MIG devices from the same
+GPU, its up to the application to know how to use them.
+
+Config for `yarn-site.xml`:
+```
+<property>
+  <name>com.nvidia.spark.NvidiaGPUMigPluginForRuntimeV2.throwOnMultipleGPUs</name>
+  <value>true</value>
+</property>
+```
+
+Environment variable for Spark application:
+```
+--conf spark.executorEnv.NVIDIA_THROW_ON_MULTIPLE_GPUS=true
+```
+
+## Using with Apache Spark on YARN
+Spark supports [scheduling GPUs and other custom resources on YARN](http://spark.apache.org/docs/latest/running-on-yarn.html#resource-allocation-and-configuration-overview). There are 2 options for using this plugin with Spark to allocate GPUs with MIG support: 
+
+- Use Spark 3.2.1 or newer and remap the standard Spark `gpu` resource (ie spark.executor.resource.gpu.amount) to be the new MIG GPU resource type using:
+```
+--conf spark.yarn.resourceGpuDeviceName=nvidia/miggpu
+```
+This means users don't have to change their configs if they were already using the `gpu` resource type.
+
+- Spark applications specify the `nvidia/miggpu` resource type instead of the `gpu` resource type. For this the user has to change the resource
+type to `nvidia/miggpu`, update the discovery script, and specify an extra YARN config(`spark.yarn.executor.resource.nvidia/miggpu.amount`).
+The command would be something like below (update the amounts according to your setup):
+```
+ --conf spark.executor.resource.nvidia/miggpu.amount=1 --conf spark.executor.resource.nvidia/miggpu.discoveryScript=./getMIGGPUs --conf spark.task.resource.nvidia/miggpu.amount=0.25 --files ./getMIGGpus --conf spark.yarn.executor.resource.nvidia/miggpu.amount=1
+```
+Note the getMIGGpus discovery script would is in the `scripts` directory in this repo. It just changes the resource name returned to match
+`nvidia/miggpu`.
+
+## Testing
+Run a Spark application using the [Rapids Accelerator for Apache Spark](https://nvidia.github.io/spark-rapids/) and request GPUs
+from YARN and verify they use the MIG enabled GPUs.

--- a/hadoop/device-plugins/gpu-mig/README.md
+++ b/hadoop/device-plugins/gpu-mig/README.md
@@ -1,7 +1,7 @@
 # NVIDIA GPU Plugin for YARN with MIG support
 
-This Plugin adds support for GPU's with [MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) on YARN. The built-in YARN GPU plugin does not support MIG enabled GPUs.
-This Plugin also works with GPUs without MIG or GPUs with MIG disabled but the limitation section still applies. It supports heterogenous environments where
+This plugin adds support for GPUs with [MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) on YARN. The built-in YARN GPU plugin does not support MIG enabled GPUs.
+This plugin also works with GPUs without MIG or GPUs with MIG disabled but the limitation section still applies. It supports heterogenous environments where
 there may be some MIG enabled GPUs and some without MIG. If you are not using MIG enabled GPUs, you should use the built-in YARN GPU plugin.
 
 ## Compatibility
@@ -13,15 +13,15 @@ It works with Apache YARN 3.3.0+ versions that support the [Pluggable Device Fra
 Please see the [MIG Application Considerations](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#app-considerations)
 and [CUDA Device Enumeration](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#cuda-visible-devices).
 
-Its important to note the with CUDA 11, only enumeration of a single MIG instance is supported, limitation. This means that this plugin
+It is important to note that CUDA 11 only supports enumeration of a single MIG instance. This means that this plugin
 only supports 1 GPU per container and the plugin will throw an exception by default if you request more.
 It is recommended that you configure YARN to only allow a single GPU be requested. See the yarn config:
 ```
  yarn.resource-types.nvidia/miggpu.maximum-allocation
 ```
 See [YARN Resource Configuration](https://hadoop.apache.org/docs/r3.3.1/hadoop-yarn/hadoop-yarn-site/ResourceModel.html) for more details.
-If you do not configure the maximum allocation and someone requests multiple GPUs, the default behavior is to throw an exception and the user
-visible exception is not very useful, the real exception will be in the nodemanager logs. See the [Configuration](#configuration) section for options on
+If you do not configure the maximum allocation and someone requests multiple GPUs, the default behavior is to throw an exception. The user
+visible exception is not very useful, as the real exception will be in the nodemanager logs. See the [Configuration](#configuration) section for options
 if it throws an exception.
 
 ## Building From Source
@@ -34,7 +34,7 @@ This will create a jar `target/yarn-gpu-mig-plugin-1.0.0.jar`. This jar can be i
 
 ## Installation
 
-Assumes YARN is already installed and configured with cgroups enabled and Nvidia Docker runtime v2.
+These instructions assume YARN is already installed and configured with cgroups enabled and Nvidia Docker runtime v2.
 Enable and configure your [GPUs with MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html) on all of the nodes it applies to.
 
 Install the jar into your Hadoop Cluster, see the [Test and Use Your Own Plugin](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/DevelopYourOwnDevicePlugin.html)
@@ -65,10 +65,11 @@ Restart YARN to pick up any configuration changes.
 
 ## Configuration
 
-To change the behavior of throwing when the user allocates multiple GPUs you can either set a config in the `yarn-site.xml` or set
-an environment variable when launching the Spark application. In either case, `true` means to throw if a user requests multiple
-GPUs(this is the default), `false` means it won't throw and if the container is allocated with multiple MIG devices from the same
-GPU, its up to the application to know how to use them.
+To change the behavior of throwing when the user allocates multiple GPUs, you can either set a config in the `yarn-site.xml` or set
+an environment variable when launching the Spark application. The environment variable will take precendence if both are set.
+In either case, `true` means to throw if a user requests multiple GPUs (this is the default), `false`
+means it won't throw and if the container is allocated with multiple MIG devices from the same
+GPU, it is up to the application to know how to use them.
 
 Config for `yarn-site.xml`:
 ```
@@ -80,13 +81,13 @@ Config for `yarn-site.xml`:
 
 Environment variable for Spark application:
 ```
---conf spark.executorEnv.NVIDIA_THROW_ON_MULTIPLE_GPUS=true
+--conf spark.executorEnv.NVIDIA_MIG_PLUGIN_THROW_ON_MULTIPLE_GPUS=true
 ```
 
 ## Using with Apache Spark on YARN
 Spark supports [scheduling GPUs and other custom resources on YARN](http://spark.apache.org/docs/latest/running-on-yarn.html#resource-allocation-and-configuration-overview). There are 2 options for using this plugin with Spark to allocate GPUs with MIG support: 
 
-- Use Spark 3.2.1 or newer and remap the standard Spark `gpu` resource (ie spark.executor.resource.gpu.amount) to be the new MIG GPU resource type using:
+- Use Spark 3.2.1 or newer and remap the standard Spark `gpu` resource (i.e.: `spark.executor.resource.gpu.amount`) to be the new MIG GPU resource type using:
 ```
 --conf spark.yarn.resourceGpuDeviceName=nvidia/miggpu
 ```

--- a/hadoop/device-plugins/gpu-mig/pom.xml
+++ b/hadoop/device-plugins/gpu-mig/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.nvidia</groupId>
+    <artifactId>yarn-gpu-mig-plugin</artifactId>
+    <name>YARN Device Plugin that supports MIG</name>
+    <description>The root project of the YARN Device Plugin that supports MIG</description>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <yarn.version>3.3.0</yarn.version>
+        <java.version>1.8</java.version>
+        <maven.compiler.version>3.8.1</maven.compiler.version>
+        <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
+        <junit.version>4.13.1</junit.version>
+        <mockito.core.version>3.4.6</mockito.core.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-server-nodemanager</artifactId>
+            <version>${yarn.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.core.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/hadoop/device-plugins/gpu-mig/scripts/getMIGGPUs
+++ b/hadoop/device-plugins/gpu-mig/scripts/getMIGGPUs
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script is a basic example script to get resource information about NVIDIA MIG GPUs.
+# It works with the NVIDIA GPU Plugin for YARN with MIG support and is expected to be run
+# in a container where the nvidia-docker-v2 plugin has taken care of mapping the MIG
+# devices. This is the same as the Aapche Spark script, except the resource name is changed
+# to match the new plugin.
+#
+# It assumes the drivers are properly installed and the nvidia-smi command is available.
+# It is not guaranteed to work on all setups so please test and customize as needed
+# for your environment. It can be passed into SPARK via the config
+# spark.{driver/executor}.resource.gpu.discoveryScript to allow the driver or executor to discover
+# the GPUs it was allocated. It assumes you are running within an isolated container where the
+# GPUs are allocated exclusively to that driver or executor.
+# It outputs a JSON formatted string that is expected by the
+# spark.{driver/executor}.resource.gpu.discoveryScript config.
+#
+# Example output: {"name": "nvidia/miggpu", "addresses":["0"]}
+
+ADDRS=`nvidia-smi --query-gpu=index --format=csv,noheader | sed -e ':a' -e 'N' -e'$!ba' -e 's/\n/","/g'`
+echo {\"name\": \"nvidia/miggpu\", \"addresses\":[\"$ADDRS\"]}

--- a/hadoop/device-plugins/gpu-mig/src/main/java/com/nvidia/spark/NvidiaGPUMigPluginForRuntimeV2.java
+++ b/hadoop/device-plugins/gpu-mig/src/main/java/com/nvidia/spark/NvidiaGPUMigPluginForRuntimeV2.java
@@ -174,17 +174,20 @@ public class NvidiaGPUMigPluginForRuntimeV2 implements DevicePlugin,
                             throw new IOException("Error finding MIG devices on GPU with " +
                                 "MIG enabled: " + migInfoOutput);
                         }
-                        LOG.info("GPU " + majorNumber + ":" + minorNumInt +
-                            " has MIG Enabled, found " + migDevCount + " MIG devices");
+                        LOG.info("Added GPU " + majorNumber + ":" + minorNumInt +
+                            " with MIG Enabled, found " + migDevCount + " MIG devices");
                     } else {
+                        Integer majorNumInt = Integer.parseInt(majorNumber);
+                        Integer minorNumInt = Integer.parseInt(minorNumber);
                         r.add(Device.Builder.newInstance()
                                 .setId(id)
-                                .setMajorNumber(Integer.parseInt(majorNumber))
-                                .setMinorNumber(Integer.parseInt(minorNumber))
+                                .setMajorNumber(majorNumInt)
+                                .setMinorNumber(minorNumInt)
                                 .setBusID(busId)
                                 .setDevPath("/dev/" + DEV_NAME_PREFIX + minorNumber)
                                 .setHealthy(true)
                                 .build());
+                        LOG.info("Added GPU " + majorNumInt + ":" + minorNumInt);
                         id++;
                     }
                 }

--- a/hadoop/device-plugins/gpu-mig/src/main/java/com/nvidia/spark/NvidiaGPUMigPluginForRuntimeV2.java
+++ b/hadoop/device-plugins/gpu-mig/src/main/java/com/nvidia/spark/NvidiaGPUMigPluginForRuntimeV2.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.Shell;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.DevicePlugin;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.DevicePluginScheduler;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.DeviceRegisterRequest;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.DeviceRuntimeSpec;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.YarnRuntimeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Nvidia GPU plugin supporting both Nvidia container runtime v2.
+ * It supports discovering and allocating MIG devices. Currently, with CUDA 11,
+ * only enumeration of a single MIG instance is supported. This means that
+ * this plugin officially only supports 1 GPU per container and by default
+ * will throw an exception if more are requested. The behavior of throwing
+ * an exception is configurable by either setting the environment variable
+ * {@code NVIDIA_THROW_ON_MULTIPLE_GPUS} or by setting the YARN config
+ * {@code com.nvidia.spark.NvidiaGPUMigPluginForRuntimeV2.throwOnMultipleGPUs}
+ * to false.
+ */
+public class NvidiaGPUMigPluginForRuntimeV2 implements DevicePlugin,
+        DevicePluginScheduler {
+    public static final Logger LOG = LoggerFactory.getLogger(
+            NvidiaGPUMigPluginForRuntimeV2.class);
+
+    public static final String NV_RESOURCE_NAME = "nvidia/miggpu";
+
+    private NvidiaCommandExecutor shellExecutor = new NvidiaCommandExecutor();
+
+    private Map<String, String> environment = new HashMap<>();
+
+    // If this environment is set, use it directly
+    private static final String ENV_BINARY_PATH = "NVIDIA_SMI_PATH";
+
+    private static final String DEFAULT_BINARY_NAME = "nvidia-smi";
+
+    private static final String DEV_NAME_PREFIX = "nvidia";
+
+    private static final String THROW_MULTI_CONF =
+            "com.nvidia.spark.NvidiaGPUMigPluginForRuntimeV2.throwOnMultipleGPUs";
+
+    private static final String THROW_MULTI_ENV = "NVIDIA_THROW_ON_MULTIPLE_GPUS";
+
+    private Boolean shouldThrowOnMultipleGPUFromConf = true;
+    private Boolean shouldThrowOnMultipleGPUFromEnv = true;
+
+    private String pathOfGpuBinary = null;
+
+    // command should not run more than 10 sec.
+    private static final int MAX_EXEC_TIMEOUT_MS = 10 * 1000;
+
+    // When executable path not set, try to search default dirs
+    // By default search /usr/bin, /bin, and /usr/local/nvidia/bin (when
+    // launched by nvidia-docker.
+    private static final String[] DEFAULT_BINARY_SEARCH_DIRS = new String[]{
+            "/usr/bin", "/bin", "/usr/local/nvidia/bin"};
+
+    // device id -> mig id, populated during discovery and used when launching
+    // containers
+    private Map<Integer, String> migDevices = new HashMap<>();
+
+    private String migInfoOutput = null;
+
+    @Override
+    public DeviceRegisterRequest getRegisterRequestInfo() throws Exception {
+        return DeviceRegisterRequest.Builder.newInstance()
+                .setResourceName(NV_RESOURCE_NAME).build();
+    }
+
+    @Override
+    public Set<Device> getDevices() throws Exception {
+        shellExecutor.searchBinary();
+        TreeSet<Device> r = new TreeSet<>();
+        String output;
+        try {
+            output = shellExecutor.getDeviceInfo();
+            String[] lines = output.trim().split("\n");
+            Configuration confs = new Configuration();
+            shouldThrowOnMultipleGPUFromConf = confs.getBoolean(THROW_MULTI_CONF, true);
+            int id = 0;
+            for (String oneLine : lines) {
+                String[] tokensEachLine = oneLine.split(",");
+                if (tokensEachLine.length != 3) {
+                    throw new Exception("Cannot parse the output to get the MIG enabled info. "
+                            + "output: " + oneLine + " expected index,pci.bus_id,mig.mode.current");
+                }
+                String minorNumber = tokensEachLine[0].trim();
+                String busId = tokensEachLine[1].trim();
+                String migMode = tokensEachLine[2].trim();
+                String majorNumber = getMajorNumber(DEV_NAME_PREFIX
+                        + minorNumber);
+
+                if (majorNumber != null) {
+                    if (migMode.equalsIgnoreCase("enabled")) {
+                        if (migInfoOutput == null) {
+                            // we get the mig info for all the GPUs on the host so only get it once
+                            migInfoOutput = shellExecutor.getDeviceMigInfo();
+                            if (migInfoOutput == null) {
+                                throw new Exception("MIG device enabled but no device info found");
+                            }
+                        }
+                        String[] linesMig = migInfoOutput.trim().split("\n");
+                        Integer minorNumInt = Integer.parseInt(minorNumber);
+                        Integer migDevCount = 0;
+                        for (int idmig = 0; idmig < linesMig.length; idmig++) {
+                            // first line should start with GPU
+                            // GPU 0: NVIDIA A30 (UUID: GPU-e7076666-0544-e103-4f65-a047fc18269e)
+                            // MIG 1g.6gb      Device  0: (UUID: MIG-de9876e2-eef7-5b5a-9701-db694ffe8a77)
+                            if (linesMig[idmig].startsWith("GPU " + minorNumInt)) {
+                                // process any MIG devices, this expects all the lines to be MIG devices until
+                                // we find one that starts with GPU
+                                String nextLine = linesMig[++idmig].trim();
+                                String regex = "MIG (.+)Device\\s+(\\d+):\\s+\\(UUID:(.*)\\)";
+                                Pattern pattern = Pattern.compile(regex);
+                                while (nextLine.startsWith("MIG")) {
+                                    Matcher matcher = pattern.matcher(nextLine);
+                                    while (matcher.find()) {
+                                        String devId = matcher.group(2);
+                                        migDevices.put(id, devId);
+                                        migDevCount++;
+                                        r.add(Device.Builder.newInstance()
+                                                .setId(id)
+                                                .setMajorNumber(Integer.parseInt(majorNumber))
+                                                .setMinorNumber(minorNumInt)
+                                                .setBusID(busId)
+                                                .setDevPath("/dev/" + DEV_NAME_PREFIX + minorNumber)
+                                                .setHealthy(true)
+                                                .setStatus(devId)
+                                                .build());
+                                        id++;
+                                        if (++idmig < linesMig.length) {
+                                            nextLine = linesMig[idmig].trim();
+                                        } else {
+                                            nextLine = "";
+                                        }
+                                    }
+                                }
+                                idmig = linesMig.length;
+                            }
+                        }
+                        if (migDevCount < 1) {
+                            throw new IOException("Error finding MIG devices: " + migInfoOutput);
+                        }
+                        LOG.info("GPU " + majorNumber + ":" + minorNumInt +
+                            " has MIG Enabled, found " + migDevCount + " MIG devices");
+                    } else {
+                        r.add(Device.Builder.newInstance()
+                                .setId(id)
+                                .setMajorNumber(Integer.parseInt(majorNumber))
+                                .setMinorNumber(Integer.parseInt(minorNumber))
+                                .setBusID(busId)
+                                .setDevPath("/dev/" + DEV_NAME_PREFIX + minorNumber)
+                                .setHealthy(true)
+                                .build());
+                        id++;
+                    }
+                }
+            }
+            return r;
+        } catch (IOException e) {
+            LOG.debug("Failed to get output from {}", pathOfGpuBinary);
+            throw new YarnException(e);
+        }
+    }
+
+    @Override
+    public DeviceRuntimeSpec onDevicesAllocated(Set<Device> allocatedDevices,
+                                                YarnRuntimeType yarnRuntime) throws Exception {
+        LOG.debug("Generating runtime spec for allocated devices: {}, {}",
+                allocatedDevices, yarnRuntime.getName());
+        if (shouldThrowOnMultipleGPUFromEnv && shouldThrowOnMultipleGPUFromConf
+                && allocatedDevices.size() > 1) {
+            throw new YarnException("Allocating more than 1 GPU per container is" +
+                    " not supported with use of MIG!");
+        }
+        if (yarnRuntime == YarnRuntimeType.RUNTIME_DOCKER) {
+            String nvidiaRuntime = "nvidia";
+            String nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES";
+            StringBuffer gpuMinorNumbersSB = new StringBuffer();
+            for (Device device : allocatedDevices) {
+                Integer minorNum = device.getMinorNumber();
+                Integer id = device.getId();
+                if (migDevices.containsKey(id)) {
+                    gpuMinorNumbersSB.append(minorNum + ":" + migDevices.get(id) + ",");
+                } else {
+                    gpuMinorNumbersSB.append(minorNum + ",");
+                }
+            }
+            String minorNumbers = gpuMinorNumbersSB.toString();
+            LOG.info("Nvidia Docker v2 assigned GPU: " + minorNumbers);
+            String deviceStr = minorNumbers.substring(0, minorNumbers.length() - 1);
+            return DeviceRuntimeSpec.Builder.newInstance()
+                    .addEnv(nvidiaVisibleDevices, deviceStr)
+                    .setContainerRuntime(nvidiaRuntime)
+                    .build();
+        }
+        return null;
+    }
+
+    @Override
+    public void onDevicesReleased(Set<Device> releasedDevices) throws Exception {
+        // do nothing
+    }
+
+    // Get major number from device name.
+    private String getMajorNumber(String devName) {
+        String output = null;
+        // output "major:minor" in hex
+        try {
+            LOG.debug("Get major numbers from /dev/{}", devName);
+            output = shellExecutor.getMajorMinorInfo(devName);
+            String[] strs = output.trim().split(":");
+            output = Integer.toString(Integer.parseInt(strs[0], 16));
+        } catch (IOException e) {
+            String msg =
+                    "Failed to get major number from reading /dev/" + devName;
+            LOG.warn(msg);
+        } catch (NumberFormatException e) {
+            LOG.error("Failed to parse device major number from stat output");
+            output = null;
+        }
+        return output;
+    }
+
+    @Override
+    public Set<Device> allocateDevices(Set<Device> availableDevices, int count,
+                                       Map<String, String> envs) {
+        Set<Device> allocation = new TreeSet<>();
+        String envShouldThrow = envs.get(THROW_MULTI_ENV);
+        if (envShouldThrow != null) {
+            shouldThrowOnMultipleGPUFromEnv = Boolean.parseBoolean(envShouldThrow);
+        } else {
+            shouldThrowOnMultipleGPUFromEnv = true;
+        }
+        // Only officially support 1 GPU per container so don't worry about topology
+        // scheduling.
+        basicSchedule(allocation, count, availableDevices);
+        return allocation;
+    }
+
+    public void basicSchedule(Set<Device> allocation, int count,
+                              Set<Device> availableDevices) {
+        // Basic scheduling
+        // allocate all available
+        if (count == availableDevices.size()) {
+            allocation.addAll(availableDevices);
+            return;
+        }
+        int number = 0;
+        for (Device d : availableDevices) {
+            allocation.add(d);
+            number++;
+            if (number == count) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * A shell wrapper class easy for test.
+     */
+    public class NvidiaCommandExecutor {
+
+        public String getDeviceInfo() throws IOException {
+            return Shell.execCommand(environment,
+                    new String[]{pathOfGpuBinary, "--query-gpu=index,pci.bus_id,mig.mode.current",
+                            "--format=csv,noheader"}, MAX_EXEC_TIMEOUT_MS);
+        }
+
+        public String getDeviceMigInfo() throws IOException {
+            return Shell.execCommand(environment,
+                    new String[]{pathOfGpuBinary, "-L"}, MAX_EXEC_TIMEOUT_MS);
+        }
+
+        public String getMajorMinorInfo(String devName) throws IOException {
+            // output "major:minor" in hex
+            Shell.ShellCommandExecutor shexec = new Shell.ShellCommandExecutor(
+                    new String[]{"stat", "-c", "%t:%T", "/dev/" + devName});
+            shexec.execute();
+            return shexec.getOutput();
+        }
+
+        public void searchBinary() throws Exception {
+            if (pathOfGpuBinary != null) {
+                LOG.info("Skip searching, the nvidia gpu binary is already set: "
+                        + pathOfGpuBinary);
+                return;
+            }
+            // search env for the binary
+            String envBinaryPath = System.getenv(ENV_BINARY_PATH);
+            if (null != envBinaryPath) {
+                if (new File(envBinaryPath).exists()) {
+                    pathOfGpuBinary = envBinaryPath;
+                    LOG.info("Use nvidia gpu binary: " + pathOfGpuBinary);
+                    return;
+                }
+            }
+            LOG.info("Search binary..");
+            // search if binary exists in default folders
+            File binaryFile;
+            boolean found = false;
+            for (String dir : DEFAULT_BINARY_SEARCH_DIRS) {
+                binaryFile = new File(dir, DEFAULT_BINARY_NAME);
+                if (binaryFile.exists()) {
+                    found = true;
+                    pathOfGpuBinary = binaryFile.getAbsolutePath();
+                    LOG.info("Found binary:" + pathOfGpuBinary);
+                    break;
+                }
+            }
+            if (!found) {
+                LOG.error("No binary found from env variable: "
+                        + ENV_BINARY_PATH + " or path "
+                        + DEFAULT_BINARY_SEARCH_DIRS.toString());
+                throw new Exception("No binary found for "
+                        + NvidiaGPUMigPluginForRuntimeV2.class);
+            }
+        }
+    }
+
+    // visible for testing
+    public void setPathOfGpuBinary(String pOfGpuBinary) {
+        this.pathOfGpuBinary = pOfGpuBinary;
+    }
+
+    // visible for testing
+    public void setShellExecutor(NvidiaCommandExecutor shellExecutor) {
+        this.shellExecutor = shellExecutor;
+    }
+
+    // visible for testing
+    public void setMigDevices(Map<Integer, String> migDevices) {
+        this.migDevices = migDevices;
+    }
+}

--- a/hadoop/device-plugins/gpu-mig/src/test/java/com/nvidia/spark/TestNvidiaGPUMigPluginForRuntimeV2.java
+++ b/hadoop/device-plugins/gpu-mig/src/test/java/com/nvidia/spark/TestNvidiaGPUMigPluginForRuntimeV2.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark;
+
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.DeviceRuntimeSpec;
+import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.YarnRuntimeType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test case for NvidiaGPUMigPluginForRuntimeV2 device plugin.
+ */
+public class TestNvidiaGPUMigPluginForRuntimeV2 {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(TestNvidiaGPUMigPluginForRuntimeV2.class);
+
+    @Test
+    public void testGetNvidiaDevices() throws Exception {
+        NvidiaGPUMigPluginForRuntimeV2.NvidiaCommandExecutor mockShell =
+                mock(NvidiaGPUMigPluginForRuntimeV2.NvidiaCommandExecutor.class);
+        String deviceInfoShellOutput =
+                "0, 00000000:04:00.0, [N/A]\n" +
+                "1, 00000000:82:00.0, Enabled";
+        String majorMinorNumber0 = "c3:0";
+        String majorMinorNumber1 = "c3:1";
+        String deviceMigInfoShellOutput =
+                "GPU 0: NVIDIA A100 80GB PCIe (UUID: GPU-aa72194b-fdd4-24b0-f659-17c929f46267)\n" +
+                "  MIG 1g.10gb     Device  0: (UUID: MIG-aa2c982c-48a9-5046-b7f8-aa4732879e02)\n" +
+                "GPU 1: NVIDIA A100 80GB PCIe (UUID: GPU-aa7153bf-c0ba-00ef-cdce-f861c34172f6)\n" +
+                "  MIG 1g.10gb     Device  0: (UUID: MIG-aa59d467-ba39-5d0a-a085-66af03246526)\n" +
+                "  MIG 1g.10gb     Device  1: (UUID: MIG-aad5cb29-8e6f-510a-8352-8e18f483dc74)" +
+        when(mockShell.getDeviceInfo()).thenReturn(deviceInfoShellOutput);
+        when(mockShell.getDeviceMigInfo()).thenReturn(deviceMigInfoShellOutput);
+        when(mockShell.getMajorMinorInfo("nvidia0"))
+                .thenReturn(majorMinorNumber0);
+        when(mockShell.getMajorMinorInfo("nvidia1"))
+                .thenReturn(majorMinorNumber1);
+        NvidiaGPUMigPluginForRuntimeV2 plugin = new NvidiaGPUMigPluginForRuntimeV2();
+        plugin.setShellExecutor(mockShell);
+        plugin.setPathOfGpuBinary("/fake/nvidia-smi");
+
+        Set<Device> expectedDevices = new TreeSet<>();
+        expectedDevices.add(Device.Builder.newInstance()
+                .setId(0).setHealthy(true)
+                .setBusID("00000000:04:00.0")
+                .setDevPath("/dev/nvidia0")
+                .setMajorNumber(195)
+                .setStatus("0")
+                .setMinorNumber(0).build());
+        expectedDevices.add(Device.Builder.newInstance()
+                .setId(1).setHealthy(true)
+                .setBusID("00000000:82:00.0")
+                .setDevPath("/dev/nvidia1")
+                .setMajorNumber(195)
+                .setStatus("0")
+                .setMinorNumber(1).build());
+        expectedDevices.add(Device.Builder.newInstance()
+                .setId(2).setHealthy(true)
+                .setBusID("00000000:82:00.0")
+                .setDevPath("/dev/nvidia1")
+                .setMajorNumber(195)
+                .setStatus("1")
+                .setMinorNumber(1).build());
+        Set<Device> devices = plugin.getDevices();
+        Assert.assertEquals(expectedDevices, devices);
+    }
+
+    @Test(expected = Exception.class)
+    public void testOnDeviceAllocatedMultiGPU() throws Exception {
+        NvidiaGPUMigPluginForRuntimeV2 plugin = new NvidiaGPUMigPluginForRuntimeV2();
+        Set<Device> allocatedDevices = new TreeSet<>();
+
+        DeviceRuntimeSpec spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DEFAULT);
+        Assert.assertNull(spec);
+
+        // allocate one device
+        allocatedDevices.add(Device.Builder.newInstance()
+                .setId(0).setHealthy(true)
+                .setBusID("00000000:04:00.0")
+                .setDevPath("/dev/nvidia0")
+                .setMajorNumber(195)
+                .setMinorNumber(0).build());
+        spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DOCKER);
+        Assert.assertEquals("nvidia", spec.getContainerRuntime());
+        Assert.assertEquals("0", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
+
+        // two device allowed
+        allocatedDevices.add(Device.Builder.newInstance()
+                .setId(0).setHealthy(true)
+                .setBusID("00000000:82:00.0")
+                .setDevPath("/dev/nvidia1")
+                .setMajorNumber(195)
+                .setMinorNumber(1).build());
+        spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DOCKER);
+    }
+
+    @Test
+    public void testOnDeviceAllocatedMig() throws Exception {
+        NvidiaGPUMigPluginForRuntimeV2 plugin = new NvidiaGPUMigPluginForRuntimeV2();
+        Set<Device> allocatedDevices = new TreeSet<>();
+
+        DeviceRuntimeSpec spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DEFAULT);
+        Assert.assertNull(spec);
+
+        Map<Integer, String> testMigDevices = new HashMap<>();
+        testMigDevices.put(0, "0");
+        plugin.setMigDevices(testMigDevices);
+
+        // allocate one device
+        allocatedDevices.add(Device.Builder.newInstance()
+                .setId(0).setHealthy(true)
+                .setBusID("00000000:04:00.0")
+                .setDevPath("/dev/nvidia0")
+                .setMajorNumber(195)
+                .setMinorNumber(0).build());
+        spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DOCKER);
+        Assert.assertEquals("nvidia", spec.getContainerRuntime());
+        Assert.assertEquals("0:0", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
+    }
+
+    @Test
+    public void testOnDeviceAllocatedNoMig() throws Exception {
+        NvidiaGPUMigPluginForRuntimeV2 plugin = new NvidiaGPUMigPluginForRuntimeV2();
+        Set<Device> allocatedDevices = new TreeSet<>();
+
+        DeviceRuntimeSpec spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DEFAULT);
+        Assert.assertNull(spec);
+
+        // allocate one device
+        allocatedDevices.add(Device.Builder.newInstance()
+                .setId(0).setHealthy(true)
+                .setBusID("00000000:04:00.0")
+                .setDevPath("/dev/nvidia0")
+                .setMajorNumber(195)
+                .setMinorNumber(0).build());
+        spec = plugin.onDevicesAllocated(allocatedDevices,
+                YarnRuntimeType.RUNTIME_DOCKER);
+        Assert.assertEquals("nvidia", spec.getContainerRuntime());
+        Assert.assertEquals("0", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
+    }
+}


### PR DESCRIPTION
This plugin works with YARN 3.3.0+ and adds in support for GPUs with MIG capabilities. 
Documentation tying it together with the Spark Rapids Plugin  will come later in the spark rapids repo.  

The documentation included should cover the details and if something isn't clear please let me know as I should enhance.

Tested manually on node with multiple A100's using YARN 3.3.1 using cgroups and docker.  
The plugin code was originally from Hadoop and modified to add MIG support. I also removed topology related scheduling code since we expect only 1 GPU per executor.  we use nvidia-smi -L to get the MIG information and parse that output.