### PR TITLE
Reduce rows to fit lower memory test environment

### DIFF
--- a/examples/pca/main.scala
+++ b/examples/pca/main.scala
@@ -18,7 +18,7 @@ import com.nvidia.spark.ml.feature.PCA
 import org.apache.spark.ml.linalg._
 import org.apache.spark.sql.functions._
 val dim = 2048
-val rows = 100000
+val rows = 1000
 val r = new scala.util.Random(0)
 
 // generate dummy data


### PR DESCRIPTION
This failed in our CI test due to OOM, so reduce rows. The speedup number can also be guaranteed in this case.

Signed-off-by: Allen Xu <allxu@nvidia.com>