### PR TITLE
Move the udf-examples module from spark-rapids repository to here

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ patching and rebuilding YARN code base to support MIG devices.
 relying on installing nvidia CLI wrappers written in `bash`, but unlike the solutions above without
 any Java code changes.
 
+### 6. Spark Rapids UDF examples
+This is examples of the GPU accelerated UDF.
+refer to this
+[guide](/examples/Spark-Rapids/udf-examples/README.md).
+
 ## API
 ### 1. Xgboost examples API
 

--- a/examples/Spark-Rapids/udf-examples/Dockerfile
+++ b/examples/Spark-Rapids/udf-examples/Dockerfile
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# A container that can be used to build UDF native code against libcudf
+ARG CUDA_VERSION=11.5.0
+ARG LINUX_VERSION=ubuntu18.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PARALLEL_LEVEL=10
+ENV PARALLEL_LEVEL=10
+
+RUN GCC_VERSION=$(bash -c '\
+CUDA_VERSION=$(nvcc --version | head -n4 | tail -n1 | cut -d" " -f5 | cut -d"," -f1); \
+CUDA_VERSION_MAJOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 1-2); \
+CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
+  if [[ "$CUDA_VERSION_MAJOR" == 9 ]]; then echo "7"; \
+  elif [[ "$CUDA_VERSION_MAJOR" == 10 ]]; then echo "8"; \
+  elif [[ "$CUDA_VERSION_MAJOR" == 11 ]]; then echo "9"; \
+  else echo "10"; \
+  fi') \
+&& apt update -y \
+&& apt install -y software-properties-common \
+&& add-apt-repository -y ppa:git-core/ppa \
+&& add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+&& add-apt-repository ppa:deadsnakes/ppa \
+&& apt update -y \
+&& apt install -y \
+   build-essential git rsync wget \
+   gcc-${GCC_VERSION} g++-${GCC_VERSION} \
+   openjdk-8-jdk maven tzdata \
+   # CMake dependencies
+   curl libssl-dev libcurl4-openssl-dev zlib1g-dev \
+&& apt autoremove -y \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+&& update-alternatives \
+   --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
+&& update-alternatives \
+   --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 \
+# Set gcc-${GCC_VERSION} as the default gcc
+&& update-alternatives --set gcc /usr/bin/gcc-${GCC_VERSION}  \
+# Set gcc-${GCC_VERSION} as the default g++
+&& update-alternatives --set g++ /usr/bin/g++-${GCC_VERSION}  \
+# Set JDK8 as the default Java
+&& update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+ARG CMAKE_VERSION=3.20.5
+
+# Install CMake
+RUN cd /tmp \
+ && curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" -o /tmp/cmake-$CMAKE_VERSION.tar.gz \
+ && tar -xvzf /tmp/cmake-$CMAKE_VERSION.tar.gz && cd /tmp/cmake-$CMAKE_VERSION \
+ && /tmp/cmake-$CMAKE_VERSION/bootstrap \
+    --system-curl \
+    --parallel=${PARALLEL_LEVEL} \
+ && make install -j${PARALLEL_LEVEL} \
+ && cd /tmp && rm -rf /tmp/cmake-$CMAKE_VERSION*
+

--- a/examples/Spark-Rapids/udf-examples/README.md
+++ b/examples/Spark-Rapids/udf-examples/README.md
@@ -1,0 +1,123 @@
+# RAPIDS Accelerated UDF Examples
+This project contains sample implementations of RAPIDS accelerated user-defined functions.
+
+## Spark Scala UDF Examples
+
+- [URLDecode](./src/main/scala/com/nvidia/spark/rapids/udf/scala/URLDecode.scala)
+  decodes URL-encoded strings using the
+  [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+- [URLEncode](./src/main/scala/com/nvidia/spark/rapids/udf/scala/URLEncode.scala)
+  URL-encodes strings using the
+  [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+
+## Spark Java UDF Examples
+
+- [URLDecode](./src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java)
+  decodes URL-encoded strings using the
+  [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+- [URLEncode](./src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java)
+  URL-encodes strings using the
+  [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+- [CosineSimilarity](./src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java)
+  computes the [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity)
+  between two float vectors using [native code](./src/main/cpp/src)
+
+## Hive UDF Examples
+
+- [URLDecode](./src/main/java/com/nvidia/spark/rapids/udf/hive/URLDecode.java)
+  implements a Hive simple UDF using the
+  [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+  to decode URL-encoded strings
+- [URLEncode](./src/main/java/com/nvidia/spark/rapids/udf/hive/URLEncode.java)
+  implements a Hive generic UDF using the
+  [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+  to URL-encode strings
+- [StringWordCount](./src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java)
+  implements a Hive simple UDF using
+  [native code](./src/main/cpp/src) to count words in strings
+
+
+## Building the Native Code Examples
+
+Some of the UDF examples use native code in their implementation.
+Building the native code requires a libcudf build environment, so these
+examples do not build by default. The `udf-native-examples` Maven profile
+can be used to include the native UDF examples in the build, i.e.: specify
+ `-Pudf-native-examples` on the `mvn` command-line.
+
+```bash
+mvn clean package -Pudf-native-examples
+```
+### Creating a libcudf Build Environment
+
+The `Dockerfile` in this directory can be used to setup a Docker image that
+provides a libcudf build environment. This repository will either need to be
+cloned or mounted into a container using that Docker image.
+The `Dockerfile` contains build arguments to control the Linux version,
+CUDA version, and other settings. See the top of the `Dockerfile` for details.
+
+```bash
+cd spark-rapids-examples/examples/Spark-Rapids/udf-examples
+docker build -t my-local:my-udf-example-ubuntu .
+docker run -it my-local:my-udf-example-ubuntu
+git clone https://github.com/NVIDIA/spark-rapids-examples.git
+cd spark-rapids-examples/examples/Spark-Rapids/udf-examples
+mvn clean package -Pudf-native-examples
+```
+
+## How to run the test cases on local mode
+After built the Native Code Examples, do the following
+
+### Prerequisites
+Download Spark and set SPARK_HOME environment variable.
+Refer to [Prerequisites](../../../docs/get-started/xgboost-examples/on-prem-cluster/standalone-python.md#Prerequisites)
+
+### Get jars from Maven Central
+[cudf-21.12.0-cuda11.jar](https://repo1.maven.org/maven2/ai/rapids/cudf/21.12.0/cudf-21.12.0-cuda11.jar)
+[rapids-4-spark_2.12-21.12.0.jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/21.12.0/rapids-4-spark_2.12-21.12.0.jar)
+
+### Launch a Spark local terminal
+
+```bash
+export SPARK_CUDF_JAR=path-to-cudf-jar
+export SPARK_RAPIDS_PLUGIN_JAR=path-to-rapids-4-spark-jar
+export SPARK_RAPIDS_UDF_EXAMPLES_JAR=path-to-udf-example-jar
+
+$SPARK_HOME/bin/pyspark --master local[*] \
+--conf spark.executor.cores=6 \
+--driver-memory 5G  \
+--executor-memory 5G  \
+--conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}:${SPARK_RAPIDS_UDF_EXAMPLES_JAR} \
+--conf spark.driver.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}:${SPARK_RAPIDS_UDF_EXAMPLES_JAR} \
+--jars ${SPARK_CUDF_JAR},${SPARK_RAPIDS_PLUGIN_JAR},${SPARK_RAPIDS_UDF_EXAMPLES_JAR} \
+--conf spark.plugins=com.nvidia.spark.SQLPlugin \
+--conf spark.rapids.sql.enabled=true
+
+```
+
+Input the following commands to test wordcount JIN UDF
+
+```bash
+from pyspark.sql.types import *
+schema = StructType([
+    StructField("c1", StringType()),
+    StructField("c2", IntegerType()),
+])
+data = [
+    ("s1",1),
+    ("s2",2),
+    ("s1",3),
+    ("s2",3),
+    ("s1",3),
+]
+df = spark.createDataFrame(
+        SparkContext.getOrCreate().parallelize(data, numSlices=2),
+        schema)
+df.createOrReplaceTempView("tab")
+
+spark.sql("CREATE TEMPORARY FUNCTION {} AS '{}'".format("wordcount", "com.nvidia.spark.rapids.udf.hive.StringWordCount"))
+spark.sql("select wordcount(c1) from tab group by c1").show()
+spark.sql("select wordcount(c1) from tab group by c1").explain()
+```
+
+Refer to [more Spark mode](../../../docs/get-started/xgboost-examples/on-prem-cluster) to test against more Spark running modes.

--- a/examples/Spark-Rapids/udf-examples/pom.xml
+++ b/examples/Spark-Rapids/udf-examples/pom.xml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020-2022, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note: rapids-4-spark release version is not published in the Maven Central -->
+<!-- Depends on its release version 21.12.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nvidia</groupId>
+        <artifactId>rapids-4-spark-parent</artifactId>
+        <!-- Depends on its release version 21.12.0 -->
+        <version>21.12.0</version>
+    </parent>
+    <artifactId>rapids-4-spark-udf-examples_2.12</artifactId>
+    <name>RAPIDS Accelerator for Apache Spark UDF Examples</name>
+    <description>Sample implementations of RAPIDS accelerated
+        user defined functions for use with the RAPIDS Accelerator
+        for Apache Spark
+    </description>
+    <version>22.04.0-SNAPSHOT</version>
+
+    <properties>
+        <udf.native.build.path>${project.build.directory}/cpp-build</udf.native.build.path>
+        <BUILD_UDF_BENCHMARKS>OFF</BUILD_UDF_BENCHMARKS>
+        <CMAKE_CXX_FLAGS/>
+        <GPU_ARCHS>ALL</GPU_ARCHS>
+        <PER_THREAD_DEFAULT_STREAM>ON</PER_THREAD_DEFAULT_STREAM>
+        <CPP_PARALLEL_LEVEL>10</CPP_PARALLEL_LEVEL>
+        <CUDF_ENABLE_ARROW_S3>OFF</CUDF_ENABLE_ARROW_S3>
+        <target.classifier/>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.rapids</groupId>
+            <artifactId>cudf</artifactId>
+            <classifier>${cuda.version}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark_${scala.binary.version}</artifactId>
+            <!-- Depends on its release version 21.12.0 -->
+            <version>21.12.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <!-- Include the properties file to provide the build information. -->
+                <directory>${project.build.directory}/extra-resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-build-info</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!--
+                 Note that we are using the Spark version for all of the Databricks dependencies as well.
+                 The jenkins/databricks/build.sh script handles installing the jars as maven artifacts.
+                 This is to make it easier and not have to change version numbers for each individual dependency
+                 and deal with differences between Databricks versions
+            -->
+            <id>dbdeps</id>
+            <activation>
+                <property>
+                    <name>databricks</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-sql_${scala.binary.version}</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-exec</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-serde</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-io</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>release311cdh</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>311cdh</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-sql_${scala.binary.version}</artifactId>
+                    <version>${spark311cdh.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.apache.curator</groupId>
+                            <artifactId>curator-recipes</artifactId>
+                        </exclusion>
+                    </exclusions>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-hive_${scala.binary.version}</artifactId>
+                    <version>${spark311cdh.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-core_${scala.binary.version}</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                    <version>4.3.0.7.2.7.0-184</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>udf-native-examples</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>${project.build.directory}/native-deps/</directory>
+                    </resource>
+                </resources>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cmake</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${udf.native.build.path}"/>
+                                        <exec dir="${udf.native.build.path}"
+                                              failonerror="true"
+                                              executable="cmake">
+                                            <arg value="${basedir}/src/main/cpp"/>
+                                            <arg value="-DBUILD_UDF_BENCHMARKS=${BUILD_UDF_BENCHMARKS}"/>
+                                            <arg value="-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"/>
+                                            <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
+                                            <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}"/>
+                                            <arg value="-DCUDF_ENABLE_ARROW_S3=${CUDF_ENABLE_ARROW_S3}"/>
+                                        </exec>
+                                        <exec failonerror="true"
+                                              executable="cmake">
+                                            <arg value="--build"/>
+                                            <arg value="${udf.native.build.path}"/>
+                                            <arg value="-j${CPP_PARALLEL_LEVEL}"/>
+                                            <arg value="-v"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-native-libs</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <overwrite>true</overwrite>
+                                    <outputDirectory>${project.build.directory}/native-deps/${os.arch}/${os.name}
+                                    </outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${udf.native.build.path}</directory>
+                                            <includes>
+                                                <include>libudfexamplesjni.so</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/CMakeLists.txt
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,175 @@
+#=============================================================================
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.04/RAPIDS.cmake
+     ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+
+include(rapids-cmake)
+include(rapids-cpm)
+include(rapids-cuda)
+include(rapids-export)
+include(rapids-find)
+
+# Use GPU_ARCHS if it is defined
+if(DEFINED GPU_ARCHS)
+  set(CMAKE_CUDA_ARCHITECTURES "${GPU_ARCHS}")
+endif()
+rapids_cuda_init_architectures(UDFEXAMPLESJNI)
+
+project(UDFEXAMPLESJNI VERSION 22.04.0 LANGUAGES C CXX CUDA)
+
+option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
+option(BUILD_UDF_BENCHMARKS "Build the benchmarks" OFF)
+
+###################################################################################################
+# - build type ------------------------------------------------------------------------------------
+
+# Set a default build type if none was specified
+set(DEFAULT_BUILD_TYPE "Release")
+
+###################################################################################################
+# - compiler options ------------------------------------------------------------------------------
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_CUDA_STANDARD 17)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
+if(CMAKE_CUDA_COMPILER_VERSION)
+  # Compute the version. from  CMAKE_CUDA_COMPILER_VERSION
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" CUDA_VERSION_MAJOR ${CMAKE_CUDA_COMPILER_VERSION})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" CUDA_VERSION_MINOR ${CMAKE_CUDA_COMPILER_VERSION})
+  set(CUDA_VERSION "${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}" CACHE STRING "Version of CUDA as computed from nvcc.")
+  mark_as_advanced(CUDA_VERSION)
+endif()
+
+message(STATUS "CUDA_VERSION_MAJOR: ${CUDA_VERSION_MAJOR}")
+message(STATUS "CUDA_VERSION_MINOR: ${CUDA_VERSION_MINOR}")
+message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
+
+# Always set this convenience variable
+set(CUDA_VERSION_STRING "${CUDA_VERSION}")
+
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relaxed-constexpr")
+
+####################################################################################################
+# - cudf -------------------------------------------------------------------------------------------
+
+# Ensure CUDA runtime is dynamic despite statically linking Arrow in libcudf
+set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
+
+rapids_cpm_init()
+rapids_cpm_find(cudf 22.04.00
+        CPM_ARGS
+        GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
+        GIT_TAG         branch-22.04
+        GIT_SHALLOW     TRUE
+        SOURCE_SUBDIR   cpp
+        OPTIONS         "BUILD_TESTS OFF"
+                        "BUILD_BENCHMARKS OFF"
+                        "CUDF_USE_ARROW_STATIC ON"
+                        "JITIFY_USE_CACHE ON"
+                        "CUDA_STATIC_RUNTIME OFF"
+                        "DISABLE_DEPRECATION_WARNING ON"
+                        "AUTO_DETECT_CUDA_ARCHITECTURES OFF"
+    )
+
+###################################################################################################
+# - benchmarks ------------------------------------------------------------------------------------
+
+if(BUILD_UDF_BENCHMARKS)
+    # Find or install GoogleBench
+    CPMFindPackage(NAME benchmark
+        VERSION         1.5.2
+        GIT_REPOSITORY  https://github.com/google/benchmark.git
+        GIT_TAG         v1.5.2
+        GIT_SHALLOW     TRUE
+        OPTIONS         "BENCHMARK_ENABLE_TESTING OFF"
+                        "BENCHMARK_ENABLE_INSTALL OFF")
+    add_subdirectory(benchmarks)
+endif()
+
+###################################################################################################
+# - find JNI -------------------------------------------------------------------------------------
+
+find_package(JNI REQUIRED)
+if(JNI_FOUND)
+    message(STATUS "JDK with JNI in ${JNI_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "JDK with JNI not found, please check your settings.")
+endif(JNI_FOUND)
+
+###################################################################################################
+# - library paths ---------------------------------------------------------------------------------
+
+# CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
+link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}"
+                 "${CMAKE_BINARY_DIR}/lib")
+
+
+###################################################################################################
+# - library targets -------------------------------------------------------------------------------
+
+set(SOURCE_FILES
+    "src/CosineSimilarityJni.cpp"
+    "src/StringWordCountJni.cpp"
+    "src/cosine_similarity.cu"
+    "src/string_word_count.cu")
+
+add_library(udfexamplesjni SHARED ${SOURCE_FILES})
+
+#Override RPATH for udfexamplesjni
+SET_TARGET_PROPERTIES(udfexamplesjni PROPERTIES BUILD_RPATH "\$ORIGIN")
+
+###################################################################################################
+# - build options ---------------------------------------------------------------------------------
+
+option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
+if(PER_THREAD_DEFAULT_STREAM)
+    message(STATUS "Using per-thread default stream")
+    target_compile_definitions(udfexamplesjni PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
+endif(PER_THREAD_DEFAULT_STREAM)
+
+target_include_directories(udfexamplesjni PRIVATE ${JNI_INCLUDE_DIRS})
+
+###################################################################################################
+# - rmm logging level -----------------------------------------------------------------------------
+
+set(RMM_LOGGING_LEVEL "OFF" CACHE STRING "Choose the logging level.")
+# Set the possible values of build type for cmake-gui
+set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS
+        "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+message(STATUS "RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'.")
+
+target_compile_definitions(udfexamplesjni
+    PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL})
+
+###################################################################################################
+# - link libraries --------------------------------------------------------------------------------
+
+target_link_libraries(udfexamplesjni cudf::cudf)

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/CMakeLists.txt
@@ -1,0 +1,36 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Use an OBJECT library so we only compile these helper source files only once
+add_library(udf_benchmark_common OBJECT
+    synchronization/synchronization.cpp)
+
+target_link_libraries(udf_benchmark_common PUBLIC benchmark::benchmark cudf)
+
+target_include_directories(udf_benchmark_common
+    PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+           "$<BUILD_INTERFACE:${UDFEXAMPLESJNI_SOURCE_DIR}>"
+           "$<BUILD_INTERFACE:${UDFEXAMPLESJNI_SOURCE_DIR}>/src")
+
+function(ConfigureBench CMAKE_BENCH_NAME)
+    add_executable(${CMAKE_BENCH_NAME} ${ARGN})
+    set_target_properties(${CMAKE_BENCH_NAME}
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${UDFEXAMPLESJNI_BINARY_DIR}/gbenchmarks>")
+    target_link_libraries(${CMAKE_BENCH_NAME}
+        PRIVATE udf_benchmark_common udfexamplesjni benchmark::benchmark_main)
+endfunction()
+
+ConfigureBench(COSINE_SIMILARITY_BENCH cosine_similarity/cosine_similarity_benchmark.cpp)

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/cosine_similarity/cosine_similarity_benchmark.cpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/cosine_similarity/cosine_similarity_benchmark.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmarks/fixture/benchmark_fixture.hpp"
+#include "benchmarks/synchronization/synchronization.hpp"
+#include "cosine_similarity.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/filling.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+
+static void cosine_similarity_bench_args(benchmark::internal::Benchmark* b)
+{
+  int const min_rows   = 1 << 12;
+  int const max_rows   = 1 << 24;
+  int const row_mult   = 8;
+  int const min_rowlen = 1 << 0;
+  int const max_rowlen = 1 << 12;
+  int const len_mult   = 8;
+  for (int row_count = min_rows; row_count <= max_rows; row_count *= row_mult) {
+    for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
+      // avoid generating combinations that exceed the cudf column limit
+      size_t total_chars = static_cast<size_t>(row_count) * rowlen;
+      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+        b->Args({row_count, rowlen});
+      }
+    }
+  }
+}
+
+static void BM_cosine_similarity(benchmark::State& state)
+{
+  cudf::size_type const n_rows{static_cast<cudf::size_type>(state.range(0))};
+  cudf::size_type const list_len{static_cast<cudf::size_type>(state.range(1))};
+
+  auto val_start = cudf::make_fixed_width_scalar(1.0f);
+  auto val_step = cudf::make_fixed_width_scalar(-1.0f);
+  auto child_rows = n_rows * list_len;
+  auto col1_child = cudf::sequence(child_rows, *val_start);
+  auto col2_child = cudf::sequence(child_rows, *val_start, *val_step);
+  auto offset_start = cudf::make_fixed_width_scalar(static_cast<int32_t>(0));
+  auto offset_step = cudf::make_fixed_width_scalar(list_len);
+  auto offsets = cudf::sequence(n_rows + 1, *offset_start, *offset_step);
+
+  auto col1 = cudf::make_lists_column(
+      n_rows,
+      std::make_unique<cudf::column>(*offsets),
+      std::move(col1_child),
+      0,
+      cudf::create_null_mask(n_rows, cudf::mask_state::ALL_VALID));
+  auto lcol1 = cudf::lists_column_view(*col1);
+  auto col2 = cudf::make_lists_column(
+      n_rows,
+      std::move(offsets),
+      std::move(col2_child),
+      0,
+      cudf::create_null_mask(n_rows, cudf::mask_state::ALL_VALID));
+  auto lcol2 = cudf::lists_column_view(*col2);
+
+  for (auto _ : state) {
+    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    auto output = cosine_similarity(lcol1, lcol2);
+  }
+
+  state.SetBytesProcessed(state.iterations() * child_rows * sizeof(float));
+}
+
+class CosineSimilarity : public native_udf::benchmark {
+};
+
+BENCHMARK_DEFINE_F(CosineSimilarity, cosine_similarity)
+(::benchmark::State& state) { BM_cosine_similarity(state); }
+
+BENCHMARK_REGISTER_F(CosineSimilarity, cosine_similarity)
+  ->Apply(cosine_similarity_bench_args)
+  ->Unit(benchmark::kMillisecond)
+  ->UseManualTime();

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+
+namespace native_udf {
+
+namespace {
+// memory resource factory helpers
+inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
+
+inline auto make_pool()
+{
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
+}
+}  // namespace
+
+/**
+ * @brief Google Benchmark fixture for native UDF benchmarks
+ *
+ * Native UDF benchmarks should use a fixture derived from this fixture class to
+ * ensure that the RAPIDS Memory Manager pool mode is used in benchmarks, which
+ * eliminates memory allocation / deallocation performance overhead from the
+ * benchmark.
+ *
+ * The SetUp and TearDown methods of this fixture initialize RMM into pool mode
+ * and finalize it, respectively. These methods are called automatically by
+ * Google Benchmark
+ *
+ * Example:
+ *
+ * template <class T>
+ * class my_benchmark : public native_udf::benchmark {
+ * public:
+ *   using TypeParam = T;
+ * };
+ *
+ * Then:
+ *
+ * BENCHMARK_TEMPLATE_DEFINE_F(my_benchmark, my_test_name, int)
+ *   (::benchmark::State& state) {
+ *     for (auto _ : state) {
+ *       // benchmark stuff
+ *     }
+ * }
+ *
+ * BENCHMARK_REGISTER_F(my_benchmark, my_test_name)->Range(128, 512);
+ */
+class benchmark : public ::benchmark::Fixture {
+ public:
+  virtual void SetUp(const ::benchmark::State& state)
+  {
+    mr = make_pool();
+    rmm::mr::set_current_device_resource(mr.get());  // set default resource to pool
+  }
+
+  virtual void TearDown(const ::benchmark::State& state)
+  {
+    // reset default resource to the initial resource
+    rmm::mr::set_current_device_resource(nullptr);
+    mr.reset();
+  }
+
+  // eliminate partial override warnings (see benchmark/benchmark.h)
+  virtual void SetUp(::benchmark::State& st) { SetUp(const_cast<const ::benchmark::State&>(st)); }
+  virtual void TearDown(::benchmark::State& st)
+  {
+    TearDown(const_cast<const ::benchmark::State&>(st));
+  }
+
+  std::shared_ptr<rmm::mr::device_memory_resource> mr;
+};
+
+}  // namespace native_udf

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "synchronization.hpp"
+
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+
+cuda_event_timer::cuda_event_timer(benchmark::State& state,
+                                   bool flush_l2_cache,
+                                   rmm::cuda_stream_view stream)
+  : stream(stream), p_state(&state)
+{
+  // flush all of L2$
+  if (flush_l2_cache) {
+    int current_device = 0;
+    CUDA_TRY(cudaGetDevice(&current_device));
+
+    int l2_cache_bytes = 0;
+    CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
+
+    if (l2_cache_bytes > 0) {
+      const int memset_value = 0;
+      rmm::device_buffer l2_cache_buffer(l2_cache_bytes, stream);
+      CUDA_TRY(
+        cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream.value()));
+    }
+  }
+
+  CUDA_TRY(cudaEventCreate(&start));
+  CUDA_TRY(cudaEventCreate(&stop));
+  CUDA_TRY(cudaEventRecord(start, stream.value()));
+}
+
+cuda_event_timer::~cuda_event_timer()
+{
+  CUDA_TRY(cudaEventRecord(stop, stream.value()));
+  CUDA_TRY(cudaEventSynchronize(stop));
+
+  float milliseconds = 0.0f;
+  CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
+  p_state->SetIterationTime(milliseconds / (1000.0f));
+  CUDA_TRY(cudaEventDestroy(start));
+  CUDA_TRY(cudaEventDestroy(stop));
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file synchronization.hpp
+ * @brief This is the header file for `cuda_event_timer`.
+ */
+
+/**
+ * @brief  This class serves as a wrapper for using `cudaEvent_t` as the user
+ * defined timer within the framework of google benchmark
+ * (https://github.com/google/benchmark).
+ *
+ * It is built on top of the idea of Resource acquisition is initialization
+ * (RAII). In the following we show a minimal example of how to use this class.
+
+    #include <benchmark/benchmark.h>
+
+    static void sample_cuda_benchmark(benchmark::State& state) {
+
+      for (auto _ : state){
+
+        rmm::cuda_stream_view stream{}; // default stream, could be another stream
+
+        // Create (Construct) an object of this class. You HAVE to pass in the
+        // benchmark::State object you are using. It measures the time from its
+        // creation to its destruction that is spent on the specified CUDA stream.
+        // It also clears the L2 cache by cudaMemset'ing a device buffer that is of
+        // the size of the L2 cache (if flush_l2_cache is set to true and there is
+        // an L2 cache on the current device).
+        cuda_event_timer raii(state, true, stream); // flush_l2_cache = true
+
+        // Now perform the operations that is to be benchmarked
+        sample_kernel<<<1, 256, 0, stream.value()>>>(); // Possibly launching a CUDA kernel
+
+      }
+    }
+
+    // Register the function as a benchmark. You will need to set the `UseManualTime()`
+    // flag in order to use the timer embedded in this class.
+    BENCHMARK(sample_cuda_benchmark)->UseManualTime();
+
+
+ */
+
+#ifndef UDF_BENCH_SYNCHRONIZATION_H
+#define UDF_BENCH_SYNCHRONIZATION_H
+
+// Google Benchmark library
+#include <benchmark/benchmark.h>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <driver_types.h>
+
+class cuda_event_timer {
+ public:
+  /**
+   * @brief This c'tor clears the L2$ by cudaMemset'ing a buffer of L2$ size
+   * and starts the timer.
+   *
+   * @param[in,out] state  This is the benchmark::State whose timer we are going
+   * to update.
+   * @param[in] flush_l2_cache_ whether or not to flush the L2 cache before
+   *                            every iteration.
+   * @param[in] stream_ The CUDA stream we are measuring time on.
+   */
+  cuda_event_timer(benchmark::State& state,
+                   bool flush_l2_cache,
+                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+  // The user must provide a benchmark::State object to set
+  // the timer so we disable the default c'tor.
+  cuda_event_timer() = delete;
+
+  // The d'tor stops the timer and performs a synchronization.
+  // Time of the benchmark::State object provided to the c'tor
+  // will be set to the value given by `cudaEventElapsedTime`.
+  ~cuda_event_timer();
+
+ private:
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  rmm::cuda_stream_view stream;
+  benchmark::State* p_state;
+};
+
+#endif

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/src/CosineSimilarityJni.cpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/src/CosineSimilarityJni.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+#include <memory>
+#include <jni.h>
+
+#include "cosine_similarity.hpp"
+
+namespace {
+
+constexpr char const* RUNTIME_ERROR_CLASS = "java/lang/RuntimeException";
+constexpr char const* ILLEGAL_ARG_CLASS   = "java/lang/IllegalArgumentException";
+
+/**
+ * @brief Throw a Java exception
+ *
+ * @param env The Java environment
+ * @param class_name The fully qualified Java class name of the exception
+ * @param msg The message string to associate with the exception
+ */
+void throw_java_exception(JNIEnv* env, char const* class_name, char const* msg) {
+  jclass ex_class = env->FindClass(class_name);
+  if (ex_class != NULL) {
+    env->ThrowNew(ex_class, msg);
+  }
+}
+
+}  // anonymous namespace
+
+extern "C" {
+
+/**
+ * @brief The native implementation of CosineSimilarity.cosineSimilarity which
+ * computes the cosine similarity between two LIST(FLOAT32) columns as a FLOAT32
+ * columnar result.
+ *
+ * @param env The Java environment
+ * @param j_view1 The address of the cudf column view of the first LIST column
+ * @param j_view2 The address of the cudf column view of the second LIST column
+ * @return The address of the cudf column containing the FLOAT32 results
+ */
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_udf_java_CosineSimilarity_cosineSimilarity(JNIEnv* env, jclass,
+                                                                        jlong j_view1,
+                                                                        jlong j_view2) {
+  // Use a try block to translate C++ exceptions into Java exceptions to avoid
+  // crashing the JVM if a C++ exception occurs.
+  try {
+    // turn the addresses into column_view pointers
+    auto v1 = reinterpret_cast<cudf::column_view const*>(j_view1);
+    auto v2 = reinterpret_cast<cudf::column_view const*>(j_view2);
+    if (v1->type().id() != v2->type().id() || v1->type().id() != cudf::type_id::LIST) {
+      throw_java_exception(env, ILLEGAL_ARG_CLASS, "inputs not list columns");
+      return 0;
+    }
+
+    // run the GPU kernel to compute the cosine similarity
+    auto lv1 = cudf::lists_column_view(*v1);
+    auto lv2 = cudf::lists_column_view(*v2);
+    std::unique_ptr<cudf::column> result = cosine_similarity(lv1, lv2);
+
+    // take ownership of the column and return the column address to Java
+    return reinterpret_cast<jlong>(result.release());
+  } catch (std::bad_alloc const& e) {
+    auto msg = std::string("Unable to allocate native memory: ") +
+        (e.what() == nullptr ? "" : e.what());
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg.c_str());
+  } catch (std::invalid_argument const& e) {
+    throw_java_exception(env, ILLEGAL_ARG_CLASS, e.what() == nullptr ? "" : e.what());
+  } catch (std::exception const& e) {
+    auto msg = e.what() == nullptr ? "" : e.what();
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg);
+  }
+  return 0;
+}
+
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/src/StringWordCountJni.cpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/src/StringWordCountJni.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+
+#include <memory>
+#include <jni.h>
+
+#include "string_word_count.hpp"
+
+namespace {
+
+constexpr char const* RUNTIME_ERROR_CLASS = "java/lang/RuntimeException";
+
+/**
+ * @brief Throw a Java exception
+ *
+ * @param env The Java environment
+ * @param class_name The fully qualified Java class name of the exception
+ * @param msg The message string to associate with the exception
+ */
+void throw_java_exception(JNIEnv* env, char const* class_name, char const* msg) {
+  jclass ex_class = env->FindClass(class_name);
+  if (ex_class != NULL) {
+    env->ThrowNew(ex_class, msg);
+  }
+}
+
+}  // anonymous namespace
+
+extern "C" {
+
+/**
+ * @brief The native implementation of StringWordCount.countWords which counts the
+ * number of words per string in a string column.
+ *
+ * @param env The Java environment
+ * @param j_strings The address of the cudf column view of the strings column
+ * @return The address of the cudf column containing the word counts
+ */
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_udf_hive_StringWordCount_countWords(JNIEnv* env, jclass,
+                                                                 jlong j_strings) {
+  // Use a try block to translate C++ exceptions into Java exceptions to avoid
+  // crashing the JVM if a C++ exception occurs.
+  try {
+    // turn the addresses into column_view pointers
+    auto strs = reinterpret_cast<cudf::column_view const*>(j_strings);
+
+    // run the GPU kernel to compute the word counts
+    std::unique_ptr<cudf::column> result = string_word_count(*strs);
+
+    // take ownership of the column and return the column address to Java
+    return reinterpret_cast<jlong>(result.release());
+  } catch (std::bad_alloc const& e) {
+    auto msg = std::string("Unable to allocate native memory: ") +
+        (e.what() == nullptr ? "" : e.what());
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg.c_str());
+  } catch (std::exception const& e) {
+    auto msg = e.what() == nullptr ? "" : e.what();
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg);
+  }
+  return 0;
+}
+
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/src/cosine_similarity.cu
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/src/cosine_similarity.cu
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cosine_similarity.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/lists/list_device_view.cuh>
+#include <cudf/lists/lists_column_device_view.cuh>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/logical.h>
+#include <thrust/transform.h>
+
+#include <cmath>
+
+namespace {
+
+/**
+ * @brief Functor for computing the cosine similarity between two list of float columns
+ */
+struct cosine_similarity_functor {
+  float const* const v1;
+  float const* const v2;
+  int32_t const* const v1_offsets;
+  int32_t const* const v2_offsets;
+
+  // This kernel executes thread-per-row which should be fine for relatively short lists
+  // but may need to be revisited for performance if operating on long lists.
+  __device__ float operator()(cudf::size_type row_idx) {
+    auto const v1_start_idx = v1_offsets[row_idx];
+    auto const v1_num_elems = v1_offsets[row_idx + 1] - v1_start_idx;
+    auto const v2_start_idx = v2_offsets[row_idx];
+    auto const v2_num_elems = v2_offsets[row_idx + 1] - v2_start_idx;
+    auto const num_elems = std::min(v1_num_elems, v2_num_elems);
+    double mag1 = 0;
+    double mag2 = 0;
+    double dot_product = 0;
+    for (auto i = 0; i < num_elems; i++) {
+      float const f1 = v1[v1_start_idx + i];
+      mag1 += f1 * f1;
+      float const f2 = v2[v2_start_idx + i];
+      mag2 += f2 * f2;
+      dot_product += f1 * f2;
+    }
+    mag1 = std::sqrt(mag1);
+    mag2 = std::sqrt(mag2);
+    return static_cast<float>(dot_product / (mag1 * mag2));
+  }
+};
+
+} // anonymous namespace
+
+/**
+ * @brief Compute the cosine similarity between two LIST of FLOAT32 columns
+ *
+ * The input vectors must have matching shapes, i.e.: same row count and same number of
+ * list elements per row. A null list row is supported, but null float entries within a
+ * list are not supported.
+ *
+ * @param lv1 The first LIST of FLOAT32 column view
+ * @param lv2 The second LIST of FLOAT32 column view
+ * @return A FLOAT32 column containing the cosine similarity corresponding to each input row
+ */
+std::unique_ptr<cudf::column> cosine_similarity(cudf::lists_column_view const& lv1,
+                                                cudf::lists_column_view const& lv2) {
+  // sanity-check the input types
+  if (lv1.child().type().id() != lv2.child().type().id() ||
+      lv1.child().type().id() != cudf::type_id::FLOAT32) {
+    throw std::invalid_argument("inputs are not lists of floats");
+  }
+
+  // sanity check the input shape
+  auto const row_count = lv1.size();
+  if (row_count != lv2.size()) {
+    throw std::invalid_argument("input row counts do not match");
+  }
+  if (row_count == 0) {
+    return cudf::make_empty_column(cudf::data_type{cudf::type_id::FLOAT32});
+  }
+  if (lv1.child().null_count() != 0 || lv2.child().null_count() != 0) {
+    throw std::invalid_argument("null floats are not supported");
+  }
+
+  auto const stream = rmm::cuda_stream_default;
+  auto d_view1_ptr = cudf::column_device_view::create(lv1.parent());
+  auto d_lists1 = cudf::detail::lists_column_device_view(*d_view1_ptr);
+  auto d_view2_ptr = cudf::column_device_view::create(lv2.parent());
+  auto d_lists2 = cudf::detail::lists_column_device_view(*d_view2_ptr);
+  bool const are_offsets_equal =
+    thrust::all_of(rmm::exec_policy(stream),
+                   thrust::make_counting_iterator<cudf::size_type>(0),
+                   thrust::make_counting_iterator<cudf::size_type>(row_count),
+                   [d_lists1, d_lists2] __device__(cudf::size_type idx) {
+                     auto ldv1 = cudf::list_device_view(d_lists1, idx);
+                     auto ldv2 = cudf::list_device_view(d_lists2, idx);
+                     return ldv1.is_null() || ldv2.is_null() || ldv1.size() == ldv2.size();
+                   });
+  if (not are_offsets_equal) {
+    throw std::invalid_argument("input list lengths do not match for every row");
+  }
+
+  // allocate the vector of float results
+  rmm::device_uvector<float> float_results(row_count, stream);
+
+  // compute the cosine similarity
+  auto const lv1_data = lv1.child().data<float>();
+  auto const lv2_data = lv2.child().data<float>();
+  auto const lv1_offsets = lv1.offsets().data<int32_t>();
+  auto const lv2_offsets = lv2.offsets().data<int32_t>();
+  thrust::transform(rmm::exec_policy(stream),
+                    thrust::make_counting_iterator<cudf::size_type>(0),
+                    thrust::make_counting_iterator<cudf::size_type>(row_count),
+                    float_results.data(),
+                    cosine_similarity_functor({lv1_data, lv2_data, lv1_offsets, lv2_offsets}));
+
+  // the validity of the output is the bitwise-and of the two input validity masks
+  auto [null_mask, null_count] = cudf::bitmask_and(cudf::table_view({lv1.parent(), lv2.parent()}));
+
+  return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::FLOAT32},
+                                        row_count,
+                                        float_results.release(),
+                                        std::move(null_mask),
+                                        null_count);
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/src/cosine_similarity.hpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/src/cosine_similarity.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+/**
+ * @brief Compute the cosine similarity between two LIST of FLOAT32 columns
+ *
+ * The input vectors must have matching shapes, i.e.: same row count and same number of
+ * list elements per row. A null list row is supported, but null float entries within a
+ * list are not supported.
+ *
+ * @param lv1 The first LIST of FLOAT32 column view
+ * @param lv2 The second LIST of FLOAT32 column view
+ * @return A FLOAT32 column containing the cosine similarity corresponding to each input row
+ */
+std::unique_ptr<cudf::column> cosine_similarity(cudf::lists_column_view const& lv1,
+                                                cudf::lists_column_view const& lv2);

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/src/string_word_count.cu
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/src/string_word_count.cu
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "string_word_count.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/strings/string_view.cuh>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform.h>
+
+namespace {
+
+// count the words separated by whitespace characters
+__device__ cudf::size_type count_words(cudf::column_device_view const& d_strings,
+                                       cudf::size_type idx) {
+  if (d_strings.is_null(idx)) return 0;
+  cudf::string_view const d_str = d_strings.element<cudf::string_view>(idx);
+  cudf::size_type word_count    = 0;
+  // run of whitespace is considered a single delimiter
+  bool spaces = true;
+  auto itr    = d_str.begin();
+  while (itr != d_str.end()) {
+    cudf::char_utf8 ch = *itr;
+    if (spaces == (ch <= ' ')) {
+      itr++;
+    } else {
+      word_count += static_cast<cudf::size_type>(spaces);
+      spaces = !spaces;
+    }
+  }
+
+  return word_count;
+}
+
+
+} // anonymous namespace
+
+/**
+ * @brief Count the words in a string using whitespace as word boundaries
+ *
+ * @param strs The column containing the strings
+ * @param stream The CUDA stream to use
+ * @return The INT32 column containing the word count results per string
+ */
+std::unique_ptr<cudf::column> string_word_count(cudf::column_view const& strs) {
+  auto strings_count = strs.size();
+  if (strings_count == 0) {
+    return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32});
+  }
+
+  // the validity of the output matches the validity of the input
+  rmm::device_buffer null_mask = cudf::copy_bitmask(strs);
+
+  // allocate the column that will contain the word count results
+  std::unique_ptr<cudf::column> result =
+    cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT32},
+      strs.size(),
+      std::move(null_mask),
+      strs.null_count());
+
+  // compute the word counts, writing into the result column data buffer
+  auto stream = rmm::cuda_stream_default;
+  auto strs_device_view = cudf::column_device_view::create(strs, stream);
+  auto d_strs_view = *strs_device_view;
+  thrust::transform(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<cudf::size_type>(0),
+    thrust::make_counting_iterator<cudf::size_type>(strings_count),
+    result->mutable_view().data<cudf::size_type>(),
+    [d_strs_view] __device__(cudf::size_type idx) { return count_words(d_strs_view, idx); });
+
+  return result;
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/cpp/src/string_word_count.hpp
+++ b/examples/Spark-Rapids/udf-examples/src/main/cpp/src/string_word_count.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+
+/**
+ * @brief Count the words in a string separated by whitespace
+ *
+ * @param strs The column containing the strings to be examined
+ * @return The INT32 column containing the word count results for each string
+ */
+std::unique_ptr<cudf::column> string_word_count(cudf::column_view const& strs);

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/DecimalFraction.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/DecimalFraction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.hive;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.Scalar;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+
+import java.math.BigDecimal;
+
+
+/**
+ * A simple HiveGenericUDF demo for DecimalType, which extracts and returns
+ * the fraction part of the input Decimal data. So, the output data has the
+ * same precision and scale as the input one.
+ */
+public class DecimalFraction extends GenericUDF implements RapidsUDF {
+  private transient PrimitiveObjectInspector inputOI;
+
+  @Override
+  public String getDisplayString(String[] strings) {
+    return getStandardDisplayString("DecimalFraction", strings);
+  }
+
+  @Override
+  public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+    if (arguments.length != 1) {
+      throw new UDFArgumentException("One argument is supported, found: " + arguments.length);
+    }
+    if (!(arguments[0] instanceof PrimitiveObjectInspector)) {
+      throw new UDFArgumentException("Unsupported argument type: " + arguments[0].getTypeName());
+    }
+
+    inputOI = (PrimitiveObjectInspector) arguments[0];
+    if (inputOI.getPrimitiveCategory() != PrimitiveObjectInspector.PrimitiveCategory.DECIMAL) {
+      throw new UDFArgumentException("Unsupported primitive type: " + inputOI.getPrimitiveCategory());
+    }
+
+    DecimalTypeInfo inputTypeInfo = (DecimalTypeInfo) inputOI.getTypeInfo();
+
+    return PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(inputTypeInfo);
+  }
+
+  @Override
+  public Object evaluate(GenericUDF.DeferredObject[] arguments) throws HiveException {
+    if (arguments[0] == null || arguments[0].get() == null) {
+      return null;
+    }
+
+    Object input = arguments[0].get();
+    HiveDecimalWritable decimalWritable = (HiveDecimalWritable) inputOI.getPrimitiveWritableObject(input);
+    BigDecimal decimalInput = decimalWritable.getHiveDecimal().bigDecimalValue();
+    BigDecimal decimalResult = decimalInput.subtract(new BigDecimal(decimalInput.toBigInteger()));
+    HiveDecimalWritable result = new HiveDecimalWritable(decimalWritable);
+    result.set(HiveDecimal.create(decimalResult));
+
+    return result;
+  }
+
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().isDecimalType()) {
+      throw new IllegalArgumentException("Argument type is not a decimal column: " +
+          input.getType());
+    }
+
+    try (Scalar nullScalar = Scalar.fromNull(input.getType());
+         ColumnVector nullPredicate = input.isNull();
+         ColumnVector integral = input.floor();
+         ColumnVector fraction = input.sub(integral, input.getType())) {
+      return nullPredicate.ifElse(nullScalar, fraction);
+    }
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/EmptyHiveGenericUDF.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/EmptyHiveGenericUDF.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.hive;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorConverter;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.Text;
+
+/** An empty Hive GenericUDF returning the input directly for row-based UDF test only */
+public class EmptyHiveGenericUDF extends GenericUDF {
+  private transient PrimitiveObjectInspectorConverter.TextConverter converter;
+  private final Text textResult = new Text();
+
+  @Override
+  public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+    if (arguments.length != 1) {
+      throw new UDFArgumentException("One argument is supported, but found: " + arguments.length);
+    }
+    if (!(arguments[0] instanceof PrimitiveObjectInspector)) {
+      throw new UDFArgumentException("Unsupported argument type: " + arguments[0].getTypeName());
+    }
+    PrimitiveObjectInspector poi = (PrimitiveObjectInspector) arguments[0];
+    converter = new PrimitiveObjectInspectorConverter.TextConverter(poi);
+    return PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+  }
+
+  @Override
+  public Object evaluate(DeferredObject[] deferredObjects) throws HiveException {
+    Text text = converter.convert(deferredObjects[0].get());
+    textResult.set(text == null ? "" : text.toString());
+    return textResult;
+  }
+
+  @Override
+  public String getDisplayString(String[] strings) {
+    return getStandardDisplayString("empty", strings);
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/EmptyHiveSimpleUDF.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/EmptyHiveSimpleUDF.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.hive;
+
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+/** An empty Hive simple UDF returning the first input directly for row-based UDF test only. */
+public class EmptyHiveSimpleUDF extends UDF {
+  public String evaluate(String in, String in2) {
+    return in;
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.hive;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.NativeDepsLoader;
+import com.nvidia.spark.RapidsUDF;
+import com.nvidia.spark.rapids.udf.java.NativeUDFExamplesLoader;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+import java.io.IOException;
+
+/**
+ * A user-defined function (UDF) that counts the words in a string.
+ * This avoids the manifestation of intermediate results required when
+ * splitting the string on whitespace and counting the split results.
+ * <p>
+ * This class demonstrates how to implement a Hive UDF with a RAPIDS
+ * implementation that uses custom native code.
+ */
+public class StringWordCount extends UDF implements RapidsUDF {
+  private volatile boolean isNativeCodeLoaded = false;
+
+  /** Row-by-row implementation that executes on the CPU */
+  public Integer evaluate(String str) {
+    if (str == null) {
+      return null;
+    }
+
+    int numWords = 0;
+    // run of whitespace is considered a single delimiter
+    boolean spaces = true;
+    for (int idx = 0; idx < str.length(); idx++) {
+      char ch = str.charAt(idx);
+      if (spaces != (ch <= ' ')) {
+        if (spaces) {
+          numWords++;
+        }
+        spaces = !spaces;
+      }
+    }
+    return numWords;
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector strs = args[0];
+    if (!strs.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("type mismatch, expected strings but found " +
+          strs.getType());
+    }
+
+    // Load the native code if it has not been already loaded. This is done here
+    // rather than in a static code block since the driver may not have the
+    // required CUDA environment.
+    NativeUDFExamplesLoader.ensureLoaded();
+
+    return new ColumnVector(countWords(strs.getNativeView()));
+  }
+
+  private static native long countWords(long stringsView);
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/URLDecode.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/URLDecode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.hive;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.Scalar;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * A Hive user-defined function (UDF) that decodes URL-encoded strings.
+ * This class demonstrates how to implement a simple Hive UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+public class URLDecode extends UDF implements RapidsUDF {
+
+  /** Row-by-row implementation that executes on the CPU */
+  public String evaluate(String s) {
+    String result = null;
+    if (s != null) {
+      try {
+        result = URLDecoder.decode(s, "utf-8");
+      } catch (IllegalArgumentException ignored) {
+        result = s;
+      } catch (UnsupportedEncodingException e) {
+        // utf-8 is a builtin, standard encoding, so this should never happen
+        throw new RuntimeException(e);
+      }
+    }
+    return result;
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("Argument type is not a string column: " +
+          input.getType());
+    }
+
+    // The cudf urlDecode does not convert '+' to a space, so do that as a pre-pass first.
+    // All intermediate results are closed to avoid leaking GPU resources.
+    try (Scalar plusScalar = Scalar.fromString("+");
+         Scalar spaceScalar = Scalar.fromString(" ");
+         ColumnVector replaced = input.stringReplace(plusScalar, spaceScalar)) {
+      return replaced.urlDecode();
+    }
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/URLEncode.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/URLEncode.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.hive;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorConverter;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.Text;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * A Hive user-defined function (UDF) that URL-encodes strings.
+ * This class demonstrates how to implement a Hive GenericUDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+public class URLEncode extends GenericUDF implements RapidsUDF {
+  private transient PrimitiveObjectInspectorConverter.TextConverter converter;
+  private final Text textResult = new Text();
+
+  /** Standard getDisplayString method for implementing GenericUDF */
+  @Override
+  public String getDisplayString(String[] children) {
+    return getStandardDisplayString("urlencode", children);
+  }
+
+  /** Standard initialize method for implementing GenericUDF for a single string parameter */
+  @Override
+  public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+    if (arguments.length != 1) {
+      throw new UDFArgumentException("One argument is supported, found: " + arguments.length);
+    }
+    if (!(arguments[0] instanceof PrimitiveObjectInspector)) {
+      throw new UDFArgumentException("Unsupported argument type: " + arguments[0].getTypeName());
+    }
+    PrimitiveObjectInspector poi = (PrimitiveObjectInspector) arguments[0];
+    switch (poi.getPrimitiveCategory()) {
+      case STRING:
+      case CHAR:
+      case VARCHAR:
+        break;
+      default:
+        throw new UDFArgumentException("Unsupported primitive type: " + poi.getPrimitiveCategory());
+    }
+
+    converter = new PrimitiveObjectInspectorConverter.TextConverter(poi);
+    return PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+  }
+
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public Object evaluate(GenericUDF.DeferredObject[] arguments) throws HiveException {
+    Text text = converter.convert(arguments[0].get());
+    if (text == null) {
+      return null;
+    }
+    String encoded;
+    try {
+      encoded = URLEncoder.encode(text.toString(), "utf-8")
+          .replace("+", "%20")
+          .replace("*", "%2A")
+          .replace("%7E", "~");
+    } catch (UnsupportedEncodingException e) {
+      // utf-8 is a builtin, standard encoding, so this should never happen
+      throw new RuntimeException(e);
+    }
+    textResult.set(encoded);
+    return textResult;
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("Argument type is not a string column: " +
+          input.getType());
+    }
+
+    return input.urlEncode();
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF2;
+import scala.collection.mutable.WrappedArray;
+
+/**
+ * A Spark Java UDF that computes the cosine similarity between two float vectors.
+ * The input vectors must have matching shapes, i.e.: same number of elements.
+ * A null vector is supported, but null entries within the vector are not supported.
+ */
+public class CosineSimilarity
+    implements UDF2<WrappedArray<Float>, WrappedArray<Float>, Float>, RapidsUDF {
+
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public Float call(WrappedArray<Float> v1, WrappedArray<Float> v2) {
+    if (v1 == null || v2 == null) {
+      return null;
+    }
+    if (v1.length() != v2.length()) {
+      throw new IllegalArgumentException("Array lengths must match: " +
+          v1.length() + " != " + v2.length());
+    }
+
+    double dotProduct = 0;
+    for (int i = 0; i < v1.length(); i++) {
+      float f1 = v1.apply(i);
+      float f2 = v2.apply(i);
+      dotProduct += f1 * f2;
+    }
+    double magProduct = magnitude(v1) * magnitude(v2);
+    return (float) (dotProduct / magProduct);
+  }
+
+  private double magnitude(WrappedArray<Float> v) {
+    double sum = 0;
+    for (int i = 0; i < v.length(); i++) {
+      float x = v.apply(i);
+      sum += x * x;
+    }
+    return Math.sqrt(sum);
+  }
+
+  /** Columnar implementation that processes data on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    if (args.length != 2) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+
+    // Load the native code if it has not been already loaded. This is done here
+    // rather than in a static code block since the driver may not have the
+    // required CUDA environment.
+    NativeUDFExamplesLoader.ensureLoaded();
+
+    return new ColumnVector(cosineSimilarity(args[0].getNativeView(), args[1].getNativeView()));
+  }
+
+  /** Native implementation that computes on the GPU */
+  private static native long cosineSimilarity(long vectorView1, long vectorView2);
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/DecimalFraction.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/DecimalFraction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.Scalar;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF1;
+
+import java.math.BigDecimal;
+
+/**
+ * A simple Java UDF demo for DecimalType, which extracts and returns the
+ * fraction part of the input Decimal data. So, the output data has the
+ * same precision and scale as the input one.
+ */
+public class DecimalFraction implements UDF1<BigDecimal, BigDecimal>, RapidsUDF {
+
+  @Override
+  public BigDecimal call(BigDecimal dec) throws Exception {
+    if (dec == null) {
+      return null;
+    }
+    BigDecimal integral = new BigDecimal(dec.toBigInteger());
+    return dec.subtract(integral);
+  }
+
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().isDecimalType()) {
+      throw new IllegalArgumentException("Argument type is not a decimal column: " +
+          input.getType());
+    }
+
+    try (Scalar nullScalar = Scalar.fromNull(input.getType());
+         ColumnVector nullPredicate = input.isNull();
+         ColumnVector integral = input.floor();
+         ColumnVector fraction = input.sub(integral, input.getType())) {
+      return nullPredicate.ifElse(nullScalar, fraction);
+    }
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/NativeUDFExamplesLoader.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/NativeUDFExamplesLoader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.NativeDepsLoader;
+
+import java.io.IOException;
+
+/** Loads the native dependencies for UDF examples with a native implementation */
+public class NativeUDFExamplesLoader {
+  private static boolean isLoaded;
+
+  /** Loads native UDF code if necessary */
+  public static synchronized void ensureLoaded() {
+    if (!isLoaded) {
+      try {
+        NativeDepsLoader.loadNativeDeps(new String[]{"udfexamplesjni"});
+        isLoaded = true;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.Scalar;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF1;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * A Java user-defined function (UDF) that decodes URL-encoded strings.
+ * This class demonstrates how to implement a Java UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+public class URLDecode implements UDF1<String, String>, RapidsUDF {
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public String call(String s) {
+    String result = null;
+    if (s != null) {
+      try {
+        result = URLDecoder.decode(s, "utf-8");
+      } catch (IllegalArgumentException ignored) {
+        result = s;
+      } catch (UnsupportedEncodingException e) {
+        // utf-8 is a builtin, standard encoding, so this should never happen
+        throw new RuntimeException(e);
+      }
+    }
+    return result;
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("Argument type is not a string column: " +
+          input.getType());
+    }
+
+    // The cudf urlDecode does not convert '+' to a space, so do that as a pre-pass first.
+    // All intermediate results are closed to avoid leaking GPU resources.
+    try (Scalar plusScalar = Scalar.fromString("+");
+         Scalar spaceScalar = Scalar.fromString(" ");
+         ColumnVector replaced = input.stringReplace(plusScalar, spaceScalar)) {
+      return replaced.urlDecode();
+    }
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java
+++ b/examples/Spark-Rapids/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF1;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * A Java user-defined function (UDF) that URL-encodes strings.
+ * This class demonstrates how to implement a Java UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+public class URLEncode implements UDF1<String, String>, RapidsUDF {
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public String call(String s) {
+    if (s == null) {
+      return null;
+    }
+    try {
+      return URLEncoder.encode(s, "utf-8")
+          .replace("+", "%20")
+          .replace("*", "%2A")
+          .replace("%7E", "~");
+    } catch (UnsupportedEncodingException e) {
+      // utf-8 is a builtin, standard encoding, so this should never happen
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("Argument type is not a string column: " +
+          input.getType());
+    }
+
+    return input.urlEncode();
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLDecode.scala
+++ b/examples/Spark-Rapids/udf-examples/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLDecode.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.scala
+
+import java.net.URLDecoder
+
+import ai.rapids.cudf.{ColumnVector, DType, Scalar}
+import com.nvidia.spark.RapidsUDF
+
+/**
+ * A Scala user-defined function (UDF) that decodes URL-encoded strings.
+ * This class demonstrates how to implement a Scala UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+class URLDecode extends Function[String, String] with RapidsUDF with Serializable {
+  /** Row-by-row implementation that executes on the CPU */
+  override def apply(s: String): String = {
+    Option(s).map { s =>
+      try {
+        URLDecoder.decode(s, "utf-8")
+      } catch {
+        case _: IllegalArgumentException => s
+      }
+    }.orNull
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    require(args.length == 1, s"Unexpected argument count: ${args.length}")
+    val input = args.head
+    require(input.getType == DType.STRING, s"Argument type is not a string: ${input.getType}")
+
+    // The cudf urlDecode does not convert '+' to a space, so do that as a pre-pass first.
+    // All intermediate results are closed to avoid leaking GPU resources.
+    val plusScalar = Scalar.fromString("+")
+    try {
+      val spaceScalar = Scalar.fromString(" ")
+      try {
+        val replaced = input.stringReplace(plusScalar, spaceScalar)
+        try {
+          replaced.urlDecode()
+        } finally {
+          replaced.close()
+        }
+      } finally {
+        spaceScalar.close()
+      }
+    } finally {
+      plusScalar.close()
+    }
+  }
+}

--- a/examples/Spark-Rapids/udf-examples/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLEncode.scala
+++ b/examples/Spark-Rapids/udf-examples/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLEncode.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.scala
+
+import java.net.URLEncoder
+
+import ai.rapids.cudf.{ColumnVector, DType}
+import com.nvidia.spark.RapidsUDF
+
+/**
+ * A Scala user-defined function (UDF) that URL-encodes strings.
+ * This class demonstrates how to implement a Scala UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+class URLEncode extends Function[String, String] with RapidsUDF with Serializable {
+  /** Row-by-row implementation that executes on the CPU */
+  override def apply(s: String): String = {
+    Option(s).map { s =>
+      URLEncoder.encode(s, "utf-8")
+          .replace("+", "%20")
+          .replace("*", "%2A")
+          .replace("%7E", "~")
+    }.orNull
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    require(args.length == 1, s"Unexpected argument count: ${args.length}")
+    val input = args.head
+    require(input.getType == DType.STRING, s"Argument type is not a string: ${input.getType}")
+    input.urlEncode()
+  }
+}


### PR DESCRIPTION
[BUG] Dependencies missing of spark-rapids v21.12.0 release jars https://github.com/NVIDIA/spark-rapids/issues/4253
Move the udf-examples module from spark-rapids repository to here

Move the udf-examples to the external repository spark-rapids-examples and the spark-rapids will no longer contain the udf-examples module.
The moved udf-examples depends on the previous release dist jar, can't depends on the Snapshot jar, because of the Snapshot jar is not published to the Maven Central.
    e.g.:  udf-examples 22.04 Snapshot depends on dist 22.02.0 version.

TODO 
Add the IT code like the spark-rapids repository.
Update the Jenkens jobs accordingly like rapids_build-it-UDF-native. 

Signed-off-by: Chong Gao <res_life@163.com>