### PR TITLE
Fix non-MIG GPU output ignored

### DIFF
--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -38,9 +38,8 @@ In `$YARN_CONF_DIR/yarn-env.sh`
 of of MIG devices as if they are physical GPU.
 - Customize `REAL_NVIDIA_SMI_PATH` value if nvidia-smi is not at the default location
 `/usr/bin/nvidia-smi`.
-- Add `ENABLE_NON_MIG_GPUS=1` if you want physical GPUs that are not subdivided in MIGs to be
-listed along with MIG sub-devices
-
+- Add `ENABLE_NON_MIG_GPUS=0` if you want to prevent discovery of physical GPUs that are not subdivided in MIGs.
+Default is ENABLE_NON_MIG_GPUS=1 and physical GPUs in the MIG-Disabled state are listed along with MIG sub-devices on the node.
 
 Modify the following config `$YARN_CONF_DIR/yarn-site.xml`:
 ```xml
@@ -74,7 +73,7 @@ path = "/usr/local/yarn-mig-scripts/nvidia-container-cli-wrapper.sh"
 environment = [ "MIG_AS_GPU_ENABLED=1",  "REAL_NVIDIA_SMI_PATH=/if/non-default/path/nvidia-smi" ]
 ```
 
-The values for `MIG_AS_GPU_ENABLED`, `REAL_NVIDIA_SMI_PATH`, `ENABLE_NON_MIG_GPUS` should be
+Note, the values for `MIG_AS_GPU_ENABLED`, `REAL_NVIDIA_SMI_PATH`, `ENABLE_NON_MIG_GPUS` should be
 identical to the ones specified in `yarn-env.sh`.
 
 ## Limitations and Caveats

--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -31,9 +31,16 @@ are executable by the docker daemon user (i.e., `root`), and YARN NM service use
 leave the original outputs untouched if the environment variable `MIG_AS_GPU_ENABLED` is not 1.
 
 ### YARN Configuration
+#### Customizing yarn-env.sh
 
-Add `export MIG_AS_GPU_ENABLED=1` to `$YARN_CONF_DIR/yarn-env.sh`.
-Customize `REAL_NVIDIA_SMI_PATH` if not at the default location `/usr/bin/nvidia-smi`.
+In `$YARN_CONF_DIR/yarn-env.sh`
+- Add `export MIG_AS_GPU_ENABLED=1` to enable replacing of MIG-enabled GPUs with a list
+of of MIG devices as if they are physical GPU.
+- Customize `REAL_NVIDIA_SMI_PATH` value if nvidia-smi is not at the default location
+`/usr/bin/nvidia-smi`.
+- Add `ENABLE_NON_MIG_GPUS=1` if you want physical GPUs that are not subdivided in MIGs to be
+listed along with MIG sub-devices
+
 
 Modify the following config `$YARN_CONF_DIR/yarn-site.xml`:
 ```xml
@@ -66,6 +73,9 @@ Modify section `[nvidia-container-cli]` in `/etc/nvidia-container-runtime/config
 path = "/usr/local/yarn-mig-scripts/nvidia-container-cli-wrapper.sh"
 environment = [ "MIG_AS_GPU_ENABLED=1",  "REAL_NVIDIA_SMI_PATH=/if/non-default/path/nvidia-smi" ]
 ```
+
+The values for `MIG_AS_GPU_ENABLED`, `REAL_NVIDIA_SMI_PATH`, `ENABLE_NON_MIG_GPUS` should be
+identical to the ones specified in `yarn-env.sh`.
 
 ## Limitations and Caveats
 Some metrics are not and cannot be broken down by MIG device. For example, `utilization` is the

--- a/examples/MIG-Support/yarn-unpatched/scripts/mig2gpu.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/mig2gpu.sh
@@ -155,6 +155,8 @@ function processParentGpuGlobals {
             $'\t'*'<current_mig>'*'</current_mig>')
                 if [[ "$line" =~ '<current_mig>Enabled</current_mig>' ]]; then
                     mig2gpu_migEnabled=1
+                else
+                    mig2gpu_migEnabled=0
                 fi
                 ;;
 
@@ -292,12 +294,12 @@ function processGpuElement {
 
 function mig2gpuMain {
     local line
-    local lineNumber=-1
+    local lineNumber
 
     # simplified regex-free parser relying on the fact
     # that nvidia-smi output is pretty-printed with tabs
     while IFS= read -r line; do
-        lineNumber=$((lineNumber+1))
+        lineNumber=${#mig2gpu_inputLines[@]}
         mig2gpu_inputLines+=("$line")
 
         case "$line" in
@@ -307,7 +309,7 @@ function mig2gpuMain {
                 mig2gpu_out+=("$line")
                 ;;
 
-            $'\t<gpu'*)
+            $'\t<gpu '*)
                 # start of a new GPU element
                 mig2gpu_gpu_lineNumberStart="$lineNumber"
                 ;;

--- a/examples/MIG-Support/yarn-unpatched/scripts/mig2gpu.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/mig2gpu.sh
@@ -29,7 +29,9 @@ set -e
 # NOTE: this is not a real XML parser, but it is sufficient to handle XML without nested
 # tags mixed on the same line. When making changes try to avoid non-bash dependencies.
 
-ENABLE_NON_MIG_GPUS=${ENABLE_NON_MIG_GPUS:-0}
+# Include both MIG and non-MIG devices by default
+# Set ENABLE_NON_MIG_GPUS=0 to discover only GPU devices with the current MIG mode Disabled
+ENABLE_NON_MIG_GPUS=${ENABLE_NON_MIG_GPUS:-1}
 
 # For stored input test: NVIDIA_SMI_QX=./src/resources/tom-nvidia-smi-xq.xml
 # For live input test: NVIDIA_SMI_QX=/dev/stdin

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
@@ -36,7 +36,12 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
         case "$arg" in
 
             "--device="*)
-                target_gpu_idx="${arg#*=}"
+                nvcli_migDeviceIds=()
+                # map CSV of indexes 0,3,10 to ,0,3,10,
+                # so we can do an easy "contains" test
+                # the device N is included if deviceArgWithLeadingTralingComma
+                # matches =~ ",N,"
+                deviceArgWithLeadingTralingComma=",${arg#*=},"
                 current_gpu_idx=-1
                 while read -r line; do
                     case "$line" in
@@ -45,17 +50,17 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
                         # gpu index, mig index
                         *"<_mig2gpu_device_id>"*)
                             current_gpu_idx=$(($current_gpu_idx+1))
-                            if [[ "$current_gpu_idx" == "$target_gpu_idx" && "$line" =~ '<_mig2gpu_device_id>'(.*)'</_mig2gpu_device_id>' ]]; then
-                                nvcli_migDeviceId="${BASH_REMATCH[1]}"
-                                break
+                            if [[ "$deviceArgWithLeadingTralingComma" =~ ",${current_gpu_idx}," && "$line" =~ '<_mig2gpu_device_id>'(.*)'</_mig2gpu_device_id>' ]]; then
+                                nvcli_migDeviceIds+=("${BASH_REMATCH[1]}")
                             fi
                             ;;
 
                     esac
                 done <<< $("$REAL_NVIDIA_SMI_PATH" -q -x | "$THIS_DIR/mig2gpu.sh")
 
-                if [[ "$nvcli_migDeviceId" != "" ]]; then
-                    realArgs+=("--device=$nvcli_migDeviceId")
+                if (( ${#nvcli_migDeviceIds[@]} )); then
+                    migDeviceIdsCsv=$(IFS=','; echo "${nvcli_migDeviceIds[*]}")
+                    realArgs+=("--device=$migDeviceIdsCsv")
                 else
                     realArgs+=("$arg")
                 fi

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
@@ -39,9 +39,9 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
                 nvcli_migDeviceIds=()
                 # map CSV of indexes 0,3,10 to ,0,3,10,
                 # so we can do an easy "contains" test
-                # the device N is included if deviceArgWithLeadingTralingComma
+                # the device N is included if deviceArgWithLeadingTrailingComma
                 # matches =~ ",N,"
-                deviceArgWithLeadingTralingComma=",${arg#*=},"
+                deviceArgWithLeadingTrailingComma=",${arg#*=},"
                 current_gpu_idx=-1
                 while read -r line; do
                     case "$line" in
@@ -50,7 +50,7 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
                         # gpu index, mig index
                         *"<_mig2gpu_device_id>"*)
                             current_gpu_idx=$(($current_gpu_idx+1))
-                            if [[ "$deviceArgWithLeadingTralingComma" =~ ",${current_gpu_idx}," && "$line" =~ '<_mig2gpu_device_id>'(.*)'</_mig2gpu_device_id>' ]]; then
+                            if [[ "$deviceArgWithLeadingTrailingComma" =~ ",${current_gpu_idx}," && "$line" =~ '<_mig2gpu_device_id>'(.*)'</_mig2gpu_device_id>' ]]; then
                                 nvcli_migDeviceIds+=("${BASH_REMATCH[1]}")
                             fi
                             ;;


### PR DESCRIPTION
## Document ENABLE_NON_MIG_GPUS and fix adding non-MIG GPUs in nvidia-smi-wrapper

- This script fails to reset migEnabled variable
such that it is ignored even if ENABLE_NON_MIG_GPUS=1

- Get rid of redundant line counter leading to occasional off-by-1 errors.
We rely on the internal size tracking of the bash input line array.


Verify with 
```bash
 MIG_AS_GPU_ENABLED=1 ENABLE_NON_MIG_GPUS=1 ./examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi-wrapper.sh -q -x | xmllint --format -
 ```

## Fix for multi-device assignments 
Before the fix providing a list of GPU indices to the wrapper would fail the docker container launch with `unknown device: unknown.`

after the fix:
```
docker run --rm --gpus '"device=0"' --runtime nvidia nvidia/cuda:11.5.1-devel-ubuntu20.04 nvidia-smi -L
GPU 0: NVIDIA A30 (UUID: GPU-05aa99be-b706-0dc1-ab62-dd12f2227b7d)
  MIG 1c.2g.12gb  Device  0: (UUID: MIG-e6af58f0-9af8-594f-825e-74d23e1a68c1)

docker run --rm --gpus '"device=2"' --runtime nvidia nvidia/cuda:11.5.1-devel-ubuntu20.04 nvidia-smi -L
GPU 0: NVIDIA A30 (UUID: GPU-05aa99be-b706-0dc1-ab62-dd12f2227b7d)
  MIG 1g.6gb      Device  0: (UUID: MIG-7e5552bf-d328-57a8-b091-0720d4530ffb)

docker run --rm --gpus '"device=0,2"' --runtime nvidia nvidia/cuda:11.5.1-devel-ubuntu20.04 nvidia-smi -L
GPU 0: NVIDIA A30 (UUID: GPU-05aa99be-b706-0dc1-ab62-dd12f2227b7d)
  MIG 1c.2g.12gb  Device  0: (UUID: MIG-e6af58f0-9af8-594f-825e-74d23e1a68c1)
  MIG 1g.6gb      Device  1: (UUID: MIG-7e5552bf-d328-57a8-b091-0720d4530ffb)
```  

Closes https://github.com/NVIDIA/spark-rapids/issues/4635


Signed-off-by: Gera Shegalov <gera@apache.org>