### PR TITLE
update version for 22.02 release

### DIFF
--- a/examples/Spark-cuML/pca/Dockerfile
+++ b/examples/Spark-cuML/pca/Dockerfile
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-ARG CUDA_VER=11.2.2
+ARG CUDA_VER=11.5.1
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu20.04
-ARG BRANCH=branch-21.12
+ARG BRANCH=branch-22.02
 
 RUN apt-get update
 RUN apt-get install -y wget ninja-build git
@@ -39,7 +39,7 @@ RUN conda --version
 RUN conda install -c conda-forge openjdk=8 maven=3.8.1 -y
 
 # install cuDF dependency.
-RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=21.12 python=3.8 cudatoolkit=11.2 -y
+RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=22.02 python=3.8 cudatoolkit=11.2 -y
 
 RUN wget --quiet \
     https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.tar.gz \
@@ -51,6 +51,8 @@ ENV PATH="/cmake-3.21.3-linux-x86_64/bin:${PATH}"
 RUN git clone -b ${BRANCH} https://github.com/rapidsai/raft.git
 
 ENV RAFT_PATH=/raft
+
+ADD settings.xml /root/.m2/
 
 RUN git clone -b ${BRANCH} https://github.com/NVIDIA/spark-rapids-ml.git \
     && cd spark-rapids-ml \

--- a/examples/Spark-cuML/pca/Dockerfile
+++ b/examples/Spark-cuML/pca/Dockerfile
@@ -52,9 +52,7 @@ RUN git clone -b ${BRANCH} https://github.com/rapidsai/raft.git
 
 ENV RAFT_PATH=/raft
 
-ADD settings.xml /root/.m2/
-
-RUN git clone -b ${BRANCH} https://github.com/NVIDIA/spark-rapids-ml.git \
+RUN git clone -b staging https://github.com/wjxiz1992/spark-rapids-ml.git \
     && cd spark-rapids-ml \
     && mvn clean
 RUN cd /spark-rapids-ml \

--- a/examples/Spark-cuML/pca/pom.xml
+++ b/examples/Spark-cuML/pca/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.nvidia</groupId>
     <artifactId>PCAExample</artifactId>
     <packaging>jar</packaging>
-    <version>22.02.0-SNAPSHOT</version>
+    <version>22.02.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/examples/Spark-cuML/pca/settings.xml
+++ b/examples/Spark-cuML/pca/settings.xml
@@ -1,0 +1,52 @@
+<settings>
+  <profiles>
+    <profile>
+      <id>sonatype-stage</id>
+      <repositories>
+        <repository>
+          <id>sonatype-staging-repo</id>
+          <name>Sonatype staging repo</name>
+          <url>https://oss.sonatype.org/content/repositories/staging</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>m2-mirror-apache0-to-urm</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <name>sw-spark-maven</name>
+          <url>https://urm.nvidia.com/artifactory/sw-spark-maven</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>m2-mirror-apache2-to-urm</id>
+      <repositories>
+        <repository>
+          <id>apache-snapshots-repo</id>
+          <name>sw-spark-maven</name>
+          <url>https://urm.nvidia.com/artifactory/sw-spark-maven</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>m2-mirror-apache3-to-urm</id>
+      <repositories>
+        <repository>
+          <id>apache-snapshots</id>
+          <name>sw-spark-maven</name>
+          <url>https://urm.nvidia.com/artifactory/sw-spark-maven</url>
+        </repository>
+      </repositories>
+    </profile>
+
+
+  </profiles>
+  <activeProfiles>
+    <activeProfile>m2-mirror-apache-to-urm</activeProfile>
+    <activeProfile>m2-mirror-apache2-to-urm</activeProfile>
+    <activeProfile>m2-mirror-apache3-to-urm</activeProfile>
+    <activeProfile>sonatype-stage</activeProfile>
+  </activeProfiles>
+</settings>

--- a/examples/Spark-cuML/pca/spark-submit.sh
+++ b/examples/Spark-cuML/pca/spark-submit.sh
@@ -16,8 +16,8 @@
 #
 
 ML_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-ml_2.12/22.02.0-SNAPSHOT/rapids-4-spark-ml_2.12-22.02.0-SNAPSHOT.jar
-CUDF_JAR=/root/.m2/repository/ai/rapids/cudf/22.02.0-SNAPSHOT/cudf-22.02.0-SNAPSHOT.jar
-PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/22.02.0-SNAPSHOT/rapids-4-spark_2.12-22.02.0-SNAPSHOT.jar
+CUDF_JAR=/root/.m2/repository/ai/rapids/cudf/22.02.0/cudf-22.02.0.jar
+PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/22.02.0/rapids-4-spark_2.12-22.02.0.jar
 
 $SPARK_HOME/bin/spark-submit \
 --master spark://127.0.0.1:7077  \
@@ -40,4 +40,4 @@ $SPARK_HOME/bin/spark-submit \
 --conf spark.network.timeout=1000s \
 --jars $ML_JAR,$CUDF_JAR,$PLUGIN_JAR \
 --class com.nvidia.spark.examples.pca.Main \
-/workspace/target/PCAExample-22.02.0-SNAPSHOT.jar
+/workspace/target/PCAExample-22.02.0.jar

--- a/examples/Spark-cuML/pca/spark-submit.sh
+++ b/examples/Spark-cuML/pca/spark-submit.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-ML_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-ml_2.12/21.12.0-SNAPSHOT/rapids-4-spark-ml_2.12-21.12.0-SNAPSHOT.jar
-CUDF_JAR=/root/.m2/repository/ai/rapids/cudf/21.12.0-SNAPSHOT/cudf-21.12.0-SNAPSHOT-cuda11.jar
-PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/21.12.0-SNAPSHOT/rapids-4-spark_2.12-21.12.0-SNAPSHOT.jar
+ML_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-ml_2.12/22.02.0-SNAPSHOT/rapids-4-spark-ml_2.12-22.02.0-SNAPSHOT.jar
+CUDF_JAR=/root/.m2/repository/ai/rapids/cudf/22.02.0-SNAPSHOT/cudf-22.02.0-SNAPSHOT.jar
+PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/22.02.0-SNAPSHOT/rapids-4-spark_2.12-22.02.0-SNAPSHOT.jar
 
 $SPARK_HOME/bin/spark-submit \
 --master spark://127.0.0.1:7077  \
@@ -28,6 +28,7 @@ $SPARK_HOME/bin/spark-submit \
 --conf spark.driver.maxResultSize=8G          \
 --conf spark.rapids.sql.enabled=true \
 --conf spark.plugins=com.nvidia.spark.SQLPlugin \
+--conf spark.rapids.cudfVersionOverride=true \
 --conf spark.rapids.memory.gpu.allocFraction=0.35 \
 --conf spark.rapids.memory.gpu.maxAllocFraction=0.6 \
 --conf spark.task.resource.gpu.amount=0.08 \
@@ -39,4 +40,4 @@ $SPARK_HOME/bin/spark-submit \
 --conf spark.network.timeout=1000s \
 --jars $ML_JAR,$CUDF_JAR,$PLUGIN_JAR \
 --class com.nvidia.spark.examples.pca.Main \
-/workspace/target/PCAExample-21.12.0-SNAPSHOT.jar
+/workspace/target/PCAExample-22.02.0-SNAPSHOT.jar


### PR DESCRIPTION
Update version numbers for upcoming 22.02 release. to fix https://github.com/NVIDIA/spark-rapids-examples/issues/98

This hasn't been ready yet as the release jars haven't been put to maven central. So a maven setting.xml file was added to download jars from internal repo. 
After release, the settings.xml file should be removed  as well as the "SNAPSHOT" words.
