### PR TITLE
Fix read of mig2gpu.sh on centos 7 and update docs 

### DIFF
--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -11,7 +11,7 @@ alternatives for more information:
 We provide a set of scripts that wrap the original `nvidia-smi` from the NVIDIA GPU Driver and `nvidia-container-cli`
 included in [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker).
 
-`nvidia-smi-wrapper.sh` is a wrapper script that parses the XML output of `nvidia-smi -q -x` used by YARN
+`nvidia-smi` is a wrapper script that parses the XML output of `nvidia-smi -q -x` used by YARN
 to discover GPUs. It replaces MIG-enabled GPUs with the list of `<gpu>` elements corresponding to every
 `<mig_device>` element of the GPU with additional annotation to construct the MIG identifier for
 `nvidia-container-cli`. This reverse mapping is performed by  modified `nvidia` Docker runtime using
@@ -38,10 +38,6 @@ to some location, for example: `/usr/local/yarn-mig-scripts`. Make sure that the
 are executable by the docker daemon user (i.e., `root`), and YARN NM service user (typically `yarn`). Note that the scripts
 leave the original outputs untouched if the environment variable `MIG_AS_GPU_ENABLED` is not 1.
 
-Please note, if using a version of YARN that includes [YARN-10593](https://issues.apache.org/jira/browse/YARN-10593),
-create a symlink to `nvidia-smi-wrapper.sh` named `nvidia-smi` in the same directory as `nvidia-smi-wrapper.sh` and
-use `nvidia-smi` in the configuration settings below.
-
 ### YARN Configuration
 #### Customizing yarn-env.sh
 
@@ -53,17 +49,16 @@ of of MIG devices as if they are physical GPU.
 - Add `ENABLE_NON_MIG_GPUS=0` if you want to prevent discovery of physical GPUs that are not subdivided in MIGs.
 Default is ENABLE_NON_MIG_GPUS=1 and physical GPUs in the MIG-Disabled state are listed along with MIG sub-devices on the node.
 
-Modify the following config `$YARN_CONF_DIR/yarn-site.xml`. The name of the script used should be `nvidia-smi` is using a
-version of YARN with [YARN-10593](https://issues.apache.org/jira/browse/YARN-10593), otherwise `nvidia-smi-wrapper.sh`.
+Modify the following config `$YARN_CONF_DIR/yarn-site.xml`.
 ```xml
 <property>
   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>
-  <value>/usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh</value>
+  <value>/usr/local/yarn-mig-scripts/</value>
 </property>
 ```
 
 By default, `yarn.nodemanager.resource-plugins.gpu.allowed-gpu-devices` is set to `auto` and
-and `/usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh` will be called by YARN to discover GPUs.
+and `/usr/local/yarn-mig-scripts/nvidia-smi` will be called by YARN to discover GPUs.
 
 If you disable the default automatic GPU discovery, you can manually
 specify the list of MIG instances to use by setting
@@ -71,7 +66,7 @@ specify the list of MIG instances to use by setting
 0-based indices corresponding to the desired `<gpu>` elements in the output of
 
 ```bash
-MIG_AS_GPU_ENABLED=1 /usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh -q -x
+MIG_AS_GPU_ENABLED=1 /usr/local/yarn-mig-scripts/nvidia-smi -q -x
 ```
 
 In other words, if you want to allow MIG 1:2 and 2:0 and they are listed as 3rd and 5th `<gpu>`

--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -52,7 +52,7 @@ of of MIG devices as if they are physical GPU.
 - Add `ENABLE_NON_MIG_GPUS=0` if you want to prevent discovery of physical GPUs that are not subdivided in MIGs.
 Default is ENABLE_NON_MIG_GPUS=1 and physical GPUs in the MIG-Disabled state are listed along with MIG sub-devices on the node.
 
-Modify the following config `$YARN_CONF_DIR/yarn-site.xml`. Name the scirpt according to what
+Modify the following config `$YARN_CONF_DIR/yarn-site.xml`. Name the script according to what
 it was copied as above:
 ```xml
 <property>

--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -49,7 +49,7 @@ of of MIG devices as if they are physical GPU.
 - Add `ENABLE_NON_MIG_GPUS=0` if you want to prevent discovery of physical GPUs that are not subdivided in MIGs.
 Default is ENABLE_NON_MIG_GPUS=1 and physical GPUs in the MIG-Disabled state are listed along with MIG sub-devices on the node.
 
-Modify the following config `$YARN_CONF_DIR/yarn-site.xml`.
+Modify the following config `$YARN_CONF_DIR/yarn-site.xml`:
 ```xml
 <property>
   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>

--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -38,8 +38,9 @@ to some location, for example: `/usr/local/yarn-mig-scripts`. Make sure that the
 are executable by the docker daemon user (i.e., `root`), and YARN NM service user (typically `yarn`). Note that the scripts
 leave the original outputs untouched if the environment variable `MIG_AS_GPU_ENABLED` is not 1.
 
-Please note that the name of the `nvidia-smi-wrapper.sh` script may need to be changed to be `nvidia-smi` if the Hadoop
-version you are using has the fix [YARN-10593](https://issues.apache.org/jira/browse/YARN-10593).
+Please note, if using a version of YARN that includes [YARN-10593](https://issues.apache.org/jira/browse/YARN-10593),
+create a symlink to `nvidia-smi-wrapper.sh` named `nvidia-smi` in the same directory as `nvidia-smi-wrapper.sh` and
+use `nvidia-smi` in the configuration settings below.
 
 ### YARN Configuration
 #### Customizing yarn-env.sh
@@ -52,8 +53,8 @@ of of MIG devices as if they are physical GPU.
 - Add `ENABLE_NON_MIG_GPUS=0` if you want to prevent discovery of physical GPUs that are not subdivided in MIGs.
 Default is ENABLE_NON_MIG_GPUS=1 and physical GPUs in the MIG-Disabled state are listed along with MIG sub-devices on the node.
 
-Modify the following config `$YARN_CONF_DIR/yarn-site.xml`. Name the script according to what
-it was copied as above:
+Modify the following config `$YARN_CONF_DIR/yarn-site.xml`. The name of the script used should be `nvidia-smi` is using a
+version of YARN with [YARN-10593](https://issues.apache.org/jira/browse/YARN-10593), otherwise `nvidia-smi-wrapper.sh`.
 ```xml
 <property>
   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>

--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -17,6 +17,13 @@ to discover GPUs. It replaces MIG-enabled GPUs with the list of `<gpu>` elements
 `nvidia-container-cli`. This reverse mapping is performed by  modified `nvidia` Docker runtime using
 `nvidia-container-cli-wrapper.sh`.
 
+## Requirements
+
+Please see the [MIG Application Considerations](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#app-considerations)
+and [CUDA Device Enumeration](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#cuda-visible-devices).
+
+Special note, that this method only works with drivers >= R470 (470.42.01+).
+
 ## Installation
 
 These instructions assume NVIDIA Container Toolkit (nvidia-docker2) and YARN is already installed
@@ -31,6 +38,9 @@ to some location, for example: `/usr/local/yarn-mig-scripts`. Make sure that the
 are executable by the docker daemon user (i.e., `root`), and YARN NM service user (typically `yarn`). Note that the scripts
 leave the original outputs untouched if the environment variable `MIG_AS_GPU_ENABLED` is not 1.
 
+Please note that the name of the `nvidia-smi-wrapper.sh` script may need to be changed to be `nvidia-smi` if the Hadoop
+version you are using has the fix [YARN-10593](https://issues.apache.org/jira/browse/YARN-10593).
+
 ### YARN Configuration
 #### Customizing yarn-env.sh
 
@@ -42,7 +52,8 @@ of of MIG devices as if they are physical GPU.
 - Add `ENABLE_NON_MIG_GPUS=0` if you want to prevent discovery of physical GPUs that are not subdivided in MIGs.
 Default is ENABLE_NON_MIG_GPUS=1 and physical GPUs in the MIG-Disabled state are listed along with MIG sub-devices on the node.
 
-Modify the following config `$YARN_CONF_DIR/yarn-site.xml`:
+Modify the following config `$YARN_CONF_DIR/yarn-site.xml`. Name the scirpt according to what
+it was copied as above:
 ```xml
 <property>
   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
@@ -56,7 +56,7 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
                             ;;
 
                     esac
-                done <<< $("$REAL_NVIDIA_SMI_PATH" -q -x | "$THIS_DIR/mig2gpu.sh")
+                done < <("$REAL_NVIDIA_SMI_PATH" -q -x | "$THIS_DIR/mig2gpu.sh")
 
                 if (( ${#nvcli_migDeviceIds[@]} )); then
                     migDeviceIdsCsv=$(IFS=','; echo "${nvcli_migDeviceIds[*]}")

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
@@ -57,6 +57,9 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
 
                     esac
                 done < <("$REAL_NVIDIA_SMI_PATH" -q -x | "$THIS_DIR/mig2gpu.sh")
+                # make sure the above redirect into the while read loop does not use the here-string (<<<) method because different
+                # versions of bash materialize newlines differently in the string. Older versions treat it as a single
+                # line and newer versions leave it as a multiline string. Here it needs to be a multiline.
 
                 if (( ${#nvcli_migDeviceIds[@]} )); then
                     migDeviceIdsCsv=$(IFS=','; echo "${nvcli_migDeviceIds[*]}")

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi
@@ -20,7 +20,7 @@
 # should point to this script on NM host, e.g
 # <property>
 #   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>
-#   <value>/usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh</value>
+#   <value>/usr/local/yarn-mig-scripts/</value>
 # </property>
 
 # customize in yarn-env.sh


### PR DESCRIPTION
While testing on centos 7 CDP cluster, I found that the nvidia-container-cli-wrapper.sh script was not properly passing on the mig device.  Debugging it I found that when it reads the output from the mig2gpu.sh and redirect into the while read line, all the output got concatenated onto a single line.  The while loop expects it to be separate lines.  I was able to fix it by changing the redirect. tested on both centos and ubuntu.

Also update the docs to include the requirement for driver version 470+ because I ran into an issue with 450 where the output of nvidia-smi was different.

I also found a YARN change that could affect the naming of the script so documented that.
