### PR TITLE
Fix read of mig2gpu.sh on centos 7 and update docs

### DIFF
--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -11,11 +11,18 @@ alternatives for more information:
 We provide a set of scripts that wrap the original `nvidia-smi` from the NVIDIA GPU Driver and `nvidia-container-cli`
 included in [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker).
 
-`nvidia-smi-wrapper.sh` is a wrapper script that parses the XML output of `nvidia-smi -q -x` used by YARN
+`nvidia-smi` is a wrapper script that parses the XML output of `nvidia-smi -q -x` used by YARN
 to discover GPUs. It replaces MIG-enabled GPUs with the list of `<gpu>` elements corresponding to every
 `<mig_device>` element of the GPU with additional annotation to construct the MIG identifier for
 `nvidia-container-cli`. This reverse mapping is performed by  modified `nvidia` Docker runtime using
 `nvidia-container-cli-wrapper.sh`.
+
+## Requirements
+
+Please see the [MIG Application Considerations](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#app-considerations)
+and [CUDA Device Enumeration](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#cuda-visible-devices).
+
+Special note, that this method only works with drivers >= R470 (470.42.01+).
 
 ## Installation
 
@@ -46,12 +53,12 @@ Modify the following config `$YARN_CONF_DIR/yarn-site.xml`:
 ```xml
 <property>
   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>
-  <value>/usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh</value>
+  <value>/usr/local/yarn-mig-scripts/</value>
 </property>
 ```
 
 By default, `yarn.nodemanager.resource-plugins.gpu.allowed-gpu-devices` is set to `auto` and
-and `/usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh` will be called by YARN to discover GPUs.
+and `/usr/local/yarn-mig-scripts/nvidia-smi` will be called by YARN to discover GPUs.
 
 If you disable the default automatic GPU discovery, you can manually
 specify the list of MIG instances to use by setting
@@ -59,7 +66,7 @@ specify the list of MIG instances to use by setting
 0-based indices corresponding to the desired `<gpu>` elements in the output of
 
 ```bash
-MIG_AS_GPU_ENABLED=1 /usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh -q -x
+MIG_AS_GPU_ENABLED=1 /usr/local/yarn-mig-scripts/nvidia-smi -q -x
 ```
 
 In other words, if you want to allow MIG 1:2 and 2:0 and they are listed as 3rd and 5th `<gpu>`

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-container-cli-wrapper.sh
@@ -56,7 +56,10 @@ if [[ "$MIG_AS_GPU_ENABLED" == "1" ]]; then
                             ;;
 
                     esac
-                done <<< $("$REAL_NVIDIA_SMI_PATH" -q -x | "$THIS_DIR/mig2gpu.sh")
+                done < <("$REAL_NVIDIA_SMI_PATH" -q -x | "$THIS_DIR/mig2gpu.sh")
+                # make sure the above redirect into the while read loop does not use the here-string (<<<) method because different
+                # versions of bash materialize newlines differently in the string. Older versions treat it as a single
+                # line and newer versions leave it as a multiline string. Here it needs to be a multiline.
 
                 if (( ${#nvcli_migDeviceIds[@]} )); then
                     migDeviceIdsCsv=$(IFS=','; echo "${nvcli_migDeviceIds[*]}")

--- a/examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi
+++ b/examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi
@@ -20,7 +20,7 @@
 # should point to this script on NM host, e.g
 # <property>
 #   <name>yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables</name>
-#   <value>/usr/local/yarn-mig-scripts/nvidia-smi-wrapper.sh</value>
+#   <value>/usr/local/yarn-mig-scripts/</value>
 # </property>
 
 # customize in yarn-env.sh


### PR DESCRIPTION
Change for branch 22.02 of PR https://github.com/NVIDIA/spark-rapids-examples/pull/114

While testing on centos 7 CDP cluster, I found that the nvidia-container-cli-wrapper.sh script was not properly passing on the mig device. Debugging it I found that when it reads the output from the mig2gpu.sh and redirect into the while read line, all the output got concatenated onto a single line. The while loop expects it to be separate lines. I was able to fix it by changing the redirect. tested on both centos and ubuntu.

Also update the docs to include the requirement for driver version 470+ because I ran into an issue with 450 where the output of nvidia-smi was different.

I also found a YARN change that could affect the naming of the script so documented that.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>