### PR TITLE
Fix PCA example docker build failure

### DIFF
--- a/examples/Spark-cuML/pca/Dockerfile
+++ b/examples/Spark-cuML/pca/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG CUDA_VER=11.5.1
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu20.04
-ARG BRANCH=branch-22.04
+ARG BRANCH_VER=22.04
 
 RUN apt-get update
 RUN apt-get install -y wget ninja-build git
@@ -39,7 +39,7 @@ RUN conda --version
 RUN conda install -c conda-forge openjdk=8 maven=3.8.1 -y
 
 # install cuDF dependency.
-RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=22.04 python=3.8 -y
+RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=${BRANCH_VER} python=3.8 -y
 
 RUN wget --quiet \
     https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.tar.gz \
@@ -48,10 +48,11 @@ RUN wget --quiet \
 
 ENV PATH="/cmake-3.21.3-linux-x86_64/bin:${PATH}"
 
-RUN git clone -b ${BRANCH} https://github.com/rapidsai/raft.git
+RUN git clone -b branch-${BRANCH_VER} https://github.com/rapidsai/raft.git
 
 ENV RAFT_PATH=/raft
 
+#use main branch to download release jars
 RUN git clone -b main https://github.com/NVIDIA/spark-rapids-ml.git \
     && cd spark-rapids-ml \
     && mvn clean

--- a/examples/Spark-cuML/pca/Dockerfile
+++ b/examples/Spark-cuML/pca/Dockerfile
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-ARG CUDA_VER=11.2.2
+ARG CUDA_VER=11.5.1
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu20.04
-ARG BRANCH=branch-21.12
+ARG BRANCH=branch-22.04
 
 RUN apt-get update
 RUN apt-get install -y wget ninja-build git
@@ -39,7 +39,7 @@ RUN conda --version
 RUN conda install -c conda-forge openjdk=8 maven=3.8.1 -y
 
 # install cuDF dependency.
-RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=21.12 python=3.8 cudatoolkit=11.2 -y
+RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=22.04 python=3.8 -y
 
 RUN wget --quiet \
     https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.tar.gz \
@@ -52,7 +52,7 @@ RUN git clone -b ${BRANCH} https://github.com/rapidsai/raft.git
 
 ENV RAFT_PATH=/raft
 
-RUN git clone -b ${BRANCH} https://github.com/NVIDIA/spark-rapids-ml.git \
+RUN git clone -b main https://github.com/NVIDIA/spark-rapids-ml.git \
     && cd spark-rapids-ml \
     && mvn clean
 RUN cd /spark-rapids-ml \


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids-examples/issues/98.
- use main branch for spark-rapids-ml to download release jars.
- change cuDF package version.

Signed-off-by: Allen Xu <allxu@nvidia.com>