### PR TITLE
Clarify mig documentation to remove cgroup references

### DIFF
--- a/examples/MIG-Support/device-plugins/gpu-mig/README.md
+++ b/examples/MIG-Support/device-plugins/gpu-mig/README.md
@@ -6,7 +6,7 @@ there may be some MIG enabled GPUs and some without MIG. If you are not using MI
 
 ## Compatibility
 
-It works with Apache YARN 3.3.0+ versions that support the [Pluggable Device Framework](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/PluggableDeviceFramework.html). This plugin requires YARN to be configured with cgroups and NVIDIA Docker runtime v2.
+It works with Apache YARN 3.3.0+ versions that support the [Pluggable Device Framework](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/PluggableDeviceFramework.html). This plugin requires YARN to be configured with Docker using the NVIDIA Container Toolkit (nvidia-docker2).
 
 ## Limitations
 
@@ -34,7 +34,7 @@ This will create a jar `target/yarn-gpu-mig-plugin-1.0.0.jar`. This jar can be i
 
 ## Installation
 
-These instructions assume YARN is already installed and configured with cgroups enabled and NVIDIA Docker runtime v2.
+These instructions assume YARN is already installed and configured with Docker enabled using the NVIDIA Container Toolkit (nvidia-docker2).
 Enable and configure your [GPUs with MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html) on all of the nodes it applies to.
 
 Install the jar into your Hadoop Cluster, see the [Test and Use Your Own Plugin](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/DevelopYourOwnDevicePlugin.html)

--- a/examples/MIG-Support/resource-types/gpu-mig/README.md
+++ b/examples/MIG-Support/resource-types/gpu-mig/README.md
@@ -9,7 +9,7 @@ environments where there may be some MIG enabled GPUs and some without MIG. This
 ## Compatibility
 
 Requires YARN 3.1.2 or newer that supports GPU scheduling. See the [supported versions](#supported-versions) section below for specific versions supported.
-MIG support requires YARN to be configured with cgroups and NVIDIA Docker runtime v2.
+MIG support requires YARN to be configured with Docker and using the NVIDIA Container Toolkit (nvidia-docker2)
 
 ## Limitations
 
@@ -51,7 +51,7 @@ mvn test -Pdist -Dtar -Dtest=TestNvidiaDockerV2CommandPlugin
 
 ## Installation
 
-This assumes YARN was already installed and configured with GPU scheduling and cgroups enabled and NVIDIA Docker runtime v2.
+These instructions assume YARN is already installed and configured with GPU Scheduling enabled using Docker and the NVIDIA Container Toolkit (nvidia-docker2).
 See [Using GPU on YARN](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/UsingGpus.html) if you need more information. 
 
 Enable and configure your [GPUs with MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html) on all of the nodes it applies to.

--- a/examples/MIG-Support/yarn-unpatched/README.md
+++ b/examples/MIG-Support/yarn-unpatched/README.md
@@ -26,9 +26,10 @@ Special note, that this method only works with drivers >= R470 (470.42.01+).
 
 ## Installation
 
-These instructions assume NVIDIA Container Toolkit (nvidia-docker2) and YARN is already installed
-and configured with GPU Scheduling and
-[CGroups enabled](https://hadoop.apache.org/docs/r3.1.2/hadoop-yarn/hadoop-yarn-site/UsingGpus.html).
+These instructions assume YARN is already installed and configured with GPU Scheduling enabled
+using Docker and the NVIDIA Container Toolkit (nvidia-docker2).
+See [Using GPU on YARN](https://hadoop.apache.org/docs/r3.1.2/hadoop-yarn/hadoop-yarn-site/UsingGpus.html) if
+you need more information.
 
 Enable and configure your [GPUs with MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html) on all of the nodes
 it applies to.


### PR DESCRIPTION
YARN doesn't need cgroups when Docker is used. isolation is through the nvidia docker v2 plugin.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>