### PR TITLE
Move to cuspatial 22.04

### DIFF
--- a/examples/Spark-cuSpatial/Dockerfile
+++ b/examples/Spark-cuSpatial/Dockerfile
@@ -38,7 +38,7 @@ RUN conda --version
 RUN conda install -c conda-forge openjdk=8 maven=3.8.1 -y
 
 # install cuDF dependency.
-RUN conda install -c rapidsai -c nvidia -c conda-forge -c defaults libcuspatial=22.02 python=3.8 -y
+RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge -c defaults libcuspatial=22.04 python=3.8 -y
 
 RUN wget --quiet \
     https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.tar.gz \

--- a/examples/Spark-cuSpatial/Dockerfile.awsdb
+++ b/examples/Spark-cuSpatial/Dockerfile.awsdb
@@ -45,7 +45,7 @@ RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.9.2-Linux-x86_
     conda config --system --set always_yes True && \
     conda clean --all
 
-RUN conda install -c rapidsai -c nvidia -c conda-forge  -c defaults libcuspatial=22.02
+RUN conda install -c rapidsai-nightly -c nvidia -c conda-forge  -c defaults libcuspatial=22.04
 RUN conda install -c conda-forge libgdal==3.3.1
 RUN pip install jupyter
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64

--- a/examples/Spark-cuSpatial/README.md
+++ b/examples/Spark-cuSpatial/README.md
@@ -72,7 +72,7 @@ We got the end-2-end time as below table when running with 2009 NYC Taxi trip pi
     * Databricks Runtime Version
   You should choose a Standard version of the Runtime version like "Runtime: 9.1 LTS(Scala 2.12, Spark 3.1.2)" and choose GPU instance type like "g4dn.xlarge". Because when I choose a ML version, it says "Support for Databricks container services requires runtime version 5.3+" and I can't click "Confirm" button.
     * Use your own Docker container
-  Input "Docker Image URL" as "<your-dockerhub-repo>:<your-tag>"
+  Input "Docker Image URL" as "your-dockerhub-repo:your-tag"
     * For the other configurations, you can follow the get-started document.
 
 3. Copy the sample [cuspatial_data.tar.gz](../../datasets/cuspatial_data.tar.gz) or your data to DBFS by using Databricks CLI.

--- a/examples/Spark-cuSpatial/src/main/native/src/PointInPolygonJni.cpp
+++ b/examples/Spark-cuSpatial/src/main/native/src/PointInPolygonJni.cpp
@@ -132,7 +132,7 @@ inline bool is_invalid_column(cudf::column_view const& col) {
  * double type, and have at least one valid row. Otherwise, the behavior is undefined.
  */
 inline double reduce_as_double(cudf::column_view const& col,
-                               std::unique_ptr<cudf::aggregation> const& agg) {
+                               std::unique_ptr<cudf::reduce_aggregation> const& agg) {
   auto s = cudf::reduce(col, agg, col.type());
   // s is always valid
   auto p_num_scalar = reinterpret_cast<cudf::numeric_scalar<double>*>(s.get());
@@ -277,8 +277,8 @@ Java_com_nvidia_spark_rapids_udf_PointInPolygon_pointInPolygon(JNIEnv* env, jcla
       return reinterpret_cast<jlong>(nulls_list.release());
     }
 
-    auto min_agg = cudf::make_min_aggregation();
-    auto max_agg = cudf::make_max_aggregation();
+    auto min_agg = cudf::make_min_aggregation<cudf::reduce_aggregation>();
+    auto max_agg = cudf::make_max_aggregation<cudf::reduce_aggregation>();
     auto x_min = reduce_as_double(*ply_x, min_agg);
     auto x_max = reduce_as_double(*ply_x, max_agg);
     auto y_min = reduce_as_double(*ply_y, min_agg);


### PR DESCRIPTION
Fix https://github.com/NVIDIA/spark-rapids-examples/issues/128
Change the code to match cuDF 22.04 API. 
cuDF 22.04 changed the parameter type to "reduce_aggregation" instead of "aggregation".
With this change, it can not be built with cuDF 22.02.
We'll update the README later.