### PR TITLE
upgrade Sample app's version

### DIFF
--- a/examples/XGBoost-Examples/agaricus/pom.xml
+++ b/examples/XGBoost-Examples/agaricus/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sample_xgboost_examples</artifactId>
         <groupId>com.nvidia</groupId>
-        <version>0.2.2</version>
+        <version>0.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/XGBoost-Examples/aggregator/pom.xml
+++ b/examples/XGBoost-Examples/aggregator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sample_xgboost_examples</artifactId>
         <groupId>com.nvidia</groupId>
-        <version>0.2.2</version>
+        <version>0.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/XGBoost-Examples/mortgage/pom.xml
+++ b/examples/XGBoost-Examples/mortgage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sample_xgboost_examples</artifactId>
         <groupId>com.nvidia</groupId>
-        <version>0.2.2</version>
+        <version>0.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/XGBoost-Examples/pom.xml
+++ b/examples/XGBoost-Examples/pom.xml
@@ -33,7 +33,7 @@
         <module>aggregator</module>
     </modules>
 
-    <version>0.2.2</version>
+    <version>0.2.3-SNAPSHOT</version>
     <name>sample_xgboost_apps</name>
 
     <properties>

--- a/examples/XGBoost-Examples/taxi/pom.xml
+++ b/examples/XGBoost-Examples/taxi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sample_xgboost_examples</artifactId>
         <groupId>com.nvidia</groupId>
-        <version>0.2.2</version>
+        <version>0.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/XGBoost-Examples/utility/pom.xml
+++ b/examples/XGBoost-Examples/utility/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sample_xgboost_examples</artifactId>
         <groupId>com.nvidia</groupId>
-        <version>0.2.2</version>
+        <version>0.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Need to upgrade Sample app's version to 0.2.3-SNAPSHOT instead of overwriting the 0.2.2

As the 0.2.2 sample app jar is used for nvidia/xgboost v1.4.2 and berfore versions supporting pyspark/CV tests

Signed-off-by: Tim Liu <timl@nvidia.com>