### PR TITLE
add rabitTrackerHost

### DIFF
--- a/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala
+++ b/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala
@@ -22,6 +22,8 @@ import com.google.common.base.CaseFormat
 import scala.collection.mutable
 import scala.util.Try
 
+import ml.dmlc.xgboost4j.scala.spark.TrackerConf
+
 private case class XGBoostArg(
   required: Boolean = false,
   parse: String => Any = value => value,
@@ -187,11 +189,16 @@ class XGBoostArgs private[utility] (
   def numFold: Int = appArgsMap.get("numFold").asInstanceOf[Option[Int]].getOrElse(3)
 
   def xgboostParams(otherParams: Map[String, Any] = Map.empty): Map[String, Any] = {
-    otherParams ++ xgbArgsMap.map{
+    val params = otherParams ++ xgbArgsMap.map{
         case (name, value) if !name.contains('_') =>
           (CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name), value)
         case (name, value) => (name, value)
     }
+
+    val hostIp = params.getOrElse("rabit_tracker_host", "").toString
+    if (!hostIp.isEmpty) {
+      params ++ Map("tracker_conf" -> TrackerConf(0l, "python", hostIp))
+    } else params
   }
 
   /**


### PR DESCRIPTION
Fix rabitTracker error on NGC

    Tracker started, with env={}
    ERROR RabitTracker$TrackerProcessLogger: Traceback (most recent call last):
    ERROR RabitTracker$TrackerProcessLogger:   File "/tmp/tracker6995309281152352559.py", line 466, in <module>
    ERROR RabitTracker$TrackerProcessLogger:     main()
    ERROR RabitTracker$TrackerProcessLogger:   File "/tmp/tracker6995309281152352559.py", line 460, in main
    ERROR RabitTracker$TrackerProcessLogger:     start_rabit_tracker(args)
    ERROR RabitTracker$TrackerProcessLogger:   File "/tmp/tracker6995309281152352559.py", line 418, in start_rabit_tracker
    ERROR RabitTracker$TrackerProcessLogger:     rabit = RabitTracker(
    ERROR RabitTracker$TrackerProcessLogger:   File "/tmp/tracker6995309281152352559.py", line 195, in __init__
    ERROR RabitTracker$TrackerProcessLogger:     sock.bind((host_ip, port))
    ERROR RabitTracker$TrackerProcessLogger: OSError: [Errno 99] Cannot assign requested address
    ERROR RabitTracker$TrackerProcessLogger: Tracker Process ends with exit code 1

Signed-off-by: Tim Liu <timl@nvidia.com>