### PR TITLE
Corret the string format of XGBoost 'rabitTrackerHost'

### DIFF
--- a/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala
+++ b/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala
@@ -97,10 +97,10 @@ object XGBoostArgs {
     println("    -saveDict=value: Boolean\n" +
       "        Whether to save the dictionary table for Mortgage ETL. It is saved under '<out>/.dict'. Default is true.\n")
     println("    -rabitTrackerHost=value: String\n" +
-      "        Specify rabit tracker host IP address. In some environments XGBoost might fail to resolve
-               the IP address of the rabit tracker, a symptom is user receiving ``OSError: [Errno 99]
-               Cannot assign requested address`` error during training.  A quick workaround is to
-               specify the address explicitly.\n")
+      "        Specify rabit tracker host IP address. In some environments XGBoost might fail to resolve\n" +
+      "        the IP address of the rabit tracker, a symptom is user receiving `OSError: [Errno 99]\n" +
+      "        Cannot assign requested address` error during training.  A quick workaround is to\n" +
+      "        specify the address explicitly.\n")
     println("For XGBoost arguments:")
     println("    Now we pass all XGBoost parameters transparently to XGBoost, no longer to verify them.")
     println("    Both of the formats are supported, such as 'numWorkers'. You can pass as either one below:")


### PR DESCRIPTION
Build Error due to wring string format in scala:  https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.08/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala#L101

```
11:23:50  [ERROR] /home/jenkins/agent/workspace/examples_xgb_build_nightly/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala:100: error: unclosed string literal
11:23:50  [INFO]       "        Specify rabit tracker host IP address. In some environments XGBoost might fail to resolve
11:23:50  [INFO]       ^
11:23:50  [ERROR] /home/jenkins/agent/workspace/examples_xgb_build_nightly/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala:101: error: empty quoted identifier
11:23:50  [ERROR]                the IP address of the rabit tracker, a symptom is user receiving ``OSError: [Errno 99]
11:23:50  [INFO]                                                                                 ^
11:23:50  [ERROR] /home/jenkins/agent/workspace/examples_xgb_build_nightly/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala:102: error: empty quoted identifier
11:23:50  [ERROR]                Cannot assign requested address`` error during training.  A quick workaround is to
11:23:50  [INFO]                                               ^
11:23:50  [ERROR] /home/jenkins/agent/workspace/examples_xgb_build_nightly/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala:103: error: unclosed string literal
11:23:50  [INFO]                specify the address explicitly.\n")
11:23:50  [INFO]                                                  ^
11:23:50  [ERROR] four errors found
11:23:50  [INFO] ------------------------------------------------------------------------
```


Build PASS locally