### PR TITLE
Keep the paths of Mortgage consistent in ETL and its downstream jobs

### DIFF
--- a/examples/XGBoost-Examples/mortgage/notebooks/python/cv-mortgage-gpu.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/python/cv-mortgage-gpu.ipynb
@@ -114,8 +114,8 @@
     "\n",
     "# You need to update them to your real paths!\n",
     "dataRoot = os.getenv(\"DATA_ROOT\", \"/data\")\n",
-    "train_path = dataRoot + \"/mortgage/train\"\n",
-    "eval_path = dataRoot + \"/mortgage/eval\"\n",
+    "train_path = dataRoot + \"/mortgage/output/train\"\n",
+    "eval_path = dataRoot + \"/mortgage/output/eval\"\n",
     "\n",
     "train_data = spark.read.parquet(train_path)\n",
     "trans_data = spark.read.parquet(eval_path)"

--- a/examples/XGBoost-Examples/mortgage/notebooks/python/mortgage-gpu.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/python/mortgage-gpu.ipynb
@@ -118,8 +118,8 @@
     "\n",
     "# You need to update them to your real paths!\n",
     "dataRoot = os.getenv(\"DATA_ROOT\", \"/data\")\n",
-    "train_path = dataRoot + \"/mortgage/train\"\n",
-    "eval_path = dataRoot + \"/mortgage/eval\"\n",
+    "train_path = dataRoot + \"/mortgage/output/train\"\n",
+    "eval_path = dataRoot + \"/mortgage/output/eval\"\n",
     "\n",
     "train_data = reader.parquet(train_path)\n",
     "trans_data = reader.parquet(eval_path)"

--- a/examples/XGBoost-Examples/mortgage/notebooks/scala/mortgage-ETL.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/scala/mortgage-ETL.ipynb
@@ -73,9 +73,10 @@
    "outputs": [],
    "source": [
     "val dataRoot = sys.env.getOrElse(\"DATA_ROOT\", \"/data\")\n",
+    "val dataOut = sys.env.getOrElse(\"DATA_OUT\", \"/data\")\n",
     "val dataPath = dataRoot + \"/mortgage/input\"\n",
-    "val outPath = dataRoot + \"/mortgage/output\"\n",
-    "val output_csv2parquet = dataRoot + \"/mortgage/output/csv2parquet/\"\n",
+    "val outPath = dataOut + \"/mortgage/output\"\n",
+    "val output_csv2parquet = dataOut + \"/mortgage/output/csv2parquet/\"\n",
     "val saveTrainEvalDataset = true"
    ]
   },

--- a/examples/XGBoost-Examples/mortgage/notebooks/scala/mortgage-gpu.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/scala/mortgage-gpu.ipynb
@@ -53,9 +53,9 @@
    "source": [
     "// You need to update them to your real paths! The input data files is the output of mortgage-etl jobs\n",
     "val dataRoot = sys.env.getOrElse(\"DATA_ROOT\", \"/data\")\n",
-    "val trainPath = dataRoot + \"/mortgage/train/\"\n",
-    "val evalPath  = dataRoot + \"/mortgage/eval/\"\n",
-    "val transPath = dataRoot + \"/mortgage/eval/\""
+    "val trainPath = dataRoot + \"/mortgage/output/train/\"\n",
+    "val evalPath  = dataRoot + \"/mortgage/output/eval/\"\n",
+    "val transPath = dataRoot + \"/mortgage/output/eval/\""
    ]
   },
   {

--- a/examples/XGBoost-Examples/mortgage/notebooks/scala/mortgage_gpu_crossvalidation.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/scala/mortgage_gpu_crossvalidation.ipynb
@@ -48,8 +48,8 @@
    "source": [
     "// You need to update them to your real paths!\n",
     "val dataRoot = sys.env.getOrElse(\"DATA_ROOT\", \"/data\")\n",
-    "val trainParquetPath=dataRoot + \"/mortgage/train\"\n",
-    "val evalParquetPath=dataRoot + \"/mortgage/eval\""
+    "val trainParquetPath=dataRoot + \"/mortgage/output/train\"\n",
+    "val evalParquetPath=dataRoot + \"/mortgage/output/eval\""
    ]
   },
   {


### PR DESCRIPTION
Follow up https://github.com/NVIDIA/spark-rapids-examples/pull/203

Keep the paths of Mortgage consistent in ETL and its downstream jobs

Add an variable to save ETL output to local.

Signed-off-by: Tim Liu <timl@nvidia.com>