### PR TITLE
Update default cmake to 3.23.X in udf exmaple dockerfile

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -58,7 +58,7 @@ CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
 # Set JDK8 as the default Java
 && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-ARG CMAKE_VERSION=3.20.5
+ARG CMAKE_VERSION=3.23.3
 
 # Install CMake
 RUN cd /tmp \

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix issue 
```
15:34:07  [INFO]      [exec] CMake Error at /home/jenkins/agent/workspace/jenkins-examples-udf-examples-native-40/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/cpp-build/_deps/rapids-cmake-src/CMakeLists.txt:28 (cmake_minimum_required):
15:34:07  [INFO]      [exec]   CMake 3.23.1 or higher is required.  You are running version 3.20.5
```
in udf example build

cudf has updated their cmake requirement to 3.23.1+, the change has been verified in CI