### PR TITLE
Pass 'rabitTrackerHost' as XGBoost arg

### DIFF
--- a/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala
+++ b/examples/XGBoost-Examples/utility/scala/src/com/nvidia/spark/examples/utility/XGBoostArgs.scala
@@ -64,7 +64,6 @@ object XGBoostArgs {
     "overwrite" -> XGBoostArg(parse = stringToBool, message = booleanMessage),
     "hasHeader" -> XGBoostArg(parse = stringToBool, message = booleanMessage),
     "saveDict"  -> XGBoostArg(parse = stringToBool, message = booleanMessage),
-    "rabitTrackerHost"  -> XGBoostArg(),
   )
 
   private def help: Unit = {


### PR DESCRIPTION
Args defined in the Map 'supportedArgs' is parsed as app/spark, not passing to XGBoost.

Remove 'rabitTrackerHost' from 'supportedArgs' Map, so that this arg can be PASS to XGBoost.

Fix issue: https://github.com/NVIDIA/spark-rapids-examples/issues/242

Signed-off-by: Tim Liu <timl@nvidia.com>