### PR TITLE
Support cpu-arch artifact for rapids-4-spark_2.12

### DIFF
--- a/examples/ML+DL-Examples/Spark-cuML/pca/spark-submit.sh
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/spark-submit.sh
@@ -15,8 +15,19 @@
 # limitations under the License.
 #
 
+arch=$(uname -m)
+case ${arch} in
+    x86_64|amd64)
+        cpu_arch='amd64';;
+    aarch64|arm64)
+        cpu_arch='arm64';;
+    *)
+      echo "Unsupport CPU architecture: ${arch}"; exit 1;;
+esac
+echo "cpu_arch is ${cpu_arch}"
+
 ML_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-ml_2.12/22.12.0-SNAPSHOT/rapids-4-spark-ml_2.12-22.12.0-SNAPSHOT.jar
-PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/22.12.0-SNAPSHOT/rapids-4-spark_2.12-22.12.0-SNAPSHOT.jar
+PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-${cpu_arch}_2.12/22.12.0-SNAPSHOT/rapids-4-spark-${cpu_arch}_2.12-22.12.0-SNAPSHOT.jar
 
 $SPARK_HOME/bin/spark-submit \
 --master spark://127.0.0.1:7077  \

--- a/examples/UDF-Examples/Spark-cuSpatial/gpu-run.sh
+++ b/examples/UDF-Examples/Spark-cuSpatial/gpu-run.sh
@@ -28,10 +28,21 @@ DATA_OUT_PATH=$ROOT_PATH/output
 
 rm -rf $DATA_OUT_PATH
 
+arch=$(uname -m)
+case ${arch} in
+    x86_64|amd64)
+        cpu_arch='amd64';;
+    aarch64|arm64)
+        cpu_arch='arm64';;
+    *)
+      echo "Unsupport CPU architecture: ${arch}"; exit 1;;
+esac
+echo "cpu_arch is ${cpu_arch}"
+
 # the path to keep the jars of spark-rapids & spark-cuspatial
 JARS=$ROOT_PATH/jars
 
-JARS_PATH=${JARS_PATH:-$JARS/rapids-4-spark_2.12-22.12.0-SNAPSHOT.jar,$JARS/spark-cuspatial-22.12.0-SNAPSHOT.jar}
+JARS_PATH=${JARS_PATH:-$JARS/rapids-4-spark-${cpu_arch}_2.12-22.12.0-SNAPSHOT.jar,$JARS/spark-cuspatial-22.12.0-SNAPSHOT.jar}
 
 $SPARK_HOME/bin/spark-submit --master spark://$HOSTNAME:7077 \
 --name "Gpu Spatial Join UDF" \


### PR DESCRIPTION
From 22.12.0 on, spark-rapids jar will suffix cup-arch to the artifact name, e.g.

rapids-4-spark-amd64_2.12 for x86 CPU architecture,

rapids-4-spark-arm64_2.12 for arm CPU architecture

Signed-off-by: Tim Liu <timl@nvidia.com>