### PR TITLE
Change the new interface of RapidsUDF

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/DecimalFraction.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/DecimalFraction.java
@@ -81,11 +81,14 @@ public class DecimalFraction extends GenericUDF implements RapidsUDF {
   }
 
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }
     ColumnVector input = args[0];
+    if (numRows != input.getRowCount()) {
+      throw new IllegalArgumentException("Expected " + numRows + " rows, received " + input.getRowCount());
+    }
     if (!input.getType().isDecimalType()) {
       throw new IllegalArgumentException("Argument type is not a decimal column: " +
           input.getType());

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java
@@ -59,13 +59,16 @@ public class StringWordCount extends UDF implements RapidsUDF {
 
   /** Columnar implementation that runs on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }
     ColumnVector strs = args[0];
+    if (numRows != strs.getRowCount()) {
+      throw new IllegalArgumentException("Expected " + numRows + " rows, received " + strs.getRowCount());
+    }
     if (!strs.getType().equals(DType.STRING)) {
       throw new IllegalArgumentException("type mismatch, expected strings but found " +
           strs.getType());

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/URLDecode.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/URLDecode.java
@@ -51,13 +51,16 @@ public class URLDecode extends UDF implements RapidsUDF {
 
   /** Columnar implementation that runs on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }
     ColumnVector input = args[0];
+    if (numRows != input.getRowCount()) {
+      throw new IllegalArgumentException("Expected " + numRows + " rows, received " + input.getRowCount());
+    }
     if (!input.getType().equals(DType.STRING)) {
       throw new IllegalArgumentException("Argument type is not a string column: " +
           input.getType());

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/URLEncode.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/hive/URLEncode.java
@@ -93,13 +93,16 @@ public class URLEncode extends GenericUDF implements RapidsUDF {
 
   /** Columnar implementation that runs on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }
     ColumnVector input = args[0];
+    if (numRows != input.getRowCount()) {
+      throw new IllegalArgumentException("Expected " + numRows + " rows, received " + input.getRowCount());
+    }
     if (!input.getType().equals(DType.STRING)) {
       throw new IllegalArgumentException("Argument type is not a string column: " +
           input.getType());

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java
@@ -61,7 +61,7 @@ public class CosineSimilarity
 
   /** Columnar implementation that processes data on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     if (args.length != 2) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/DecimalFraction.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/DecimalFraction.java
@@ -40,7 +40,7 @@ public class DecimalFraction implements UDF1<BigDecimal, BigDecimal>, RapidsUDF 
   }
 
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java
@@ -51,13 +51,16 @@ public class URLDecode implements UDF1<String, String>, RapidsUDF {
 
   /** Columnar implementation that runs on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }
     ColumnVector input = args[0];
+    if (numRows != input.getRowCount()) {
+      throw new IllegalArgumentException("Expected " + numRows + " rows, received " + input.getRowCount());
+    }
     if (!input.getType().equals(DType.STRING)) {
       throw new IllegalArgumentException("Argument type is not a string column: " +
           input.getType());

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java
@@ -50,13 +50,16 @@ public class URLEncode implements UDF1<String, String>, RapidsUDF {
 
   /** Columnar implementation that runs on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     if (args.length != 1) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length);
     }
     ColumnVector input = args[0];
+    if (numRows != input.getRowCount()) {
+      throw new IllegalArgumentException("Expected " + numRows + " rows, received " + input.getRowCount());
+    }
     if (!input.getType().equals(DType.STRING)) {
       throw new IllegalArgumentException("Argument type is not a string column: " +
           input.getType());

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLDecode.scala
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLDecode.scala
@@ -40,11 +40,12 @@ class URLDecode extends Function[String, String] with RapidsUDF with Serializabl
   }
 
   /** Columnar implementation that runs on the GPU */
-  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+  override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     require(args.length == 1, s"Unexpected argument count: ${args.length}")
     val input = args.head
+    require(numRows == input.getRowCount, s"Expected $numRows rows, received ${input.getRowCount}")
     require(input.getType == DType.STRING, s"Argument type is not a string: ${input.getType}")
 
     // The cudf urlDecode does not convert '+' to a space, so do that as a pre-pass first.

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLEncode.scala
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLEncode.scala
@@ -39,11 +39,12 @@ class URLEncode extends Function[String, String] with RapidsUDF with Serializabl
   }
 
   /** Columnar implementation that runs on the GPU */
-  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+  override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     require(args.length == 1, s"Unexpected argument count: ${args.length}")
     val input = args.head
+    require(numRows == input.getRowCount, s"Expected $numRows rows, received ${input.getRowCount}")
     require(input.getType == DType.STRING, s"Argument type is not a string: ${input.getType}")
     input.urlEncode()
   }

--- a/examples/UDF-Examples/Spark-cuSpatial/src/main/java/com/nvidia/spark/rapids/udf/PointInPolygon.java
+++ b/examples/UDF-Examples/Spark-cuSpatial/src/main/java/com/nvidia/spark/rapids/udf/PointInPolygon.java
@@ -116,7 +116,7 @@ public class PointInPolygon implements UDF2<Double, Double, List<Integer>>, Rapi
 
   /** Columnar implementation that processes data on the GPU */
   @Override
-  public ColumnVector evaluateColumnar(ColumnVector... args) {
+  public ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
     if (args.length != 2) {
       throw new IllegalArgumentException("Unexpected argument count: " + args.length +
           ", expects 2 for (x, y)");


### PR DESCRIPTION
RapidsUDF.evaluateColumnar has a new parameter of numRows
Close https://github.com/NVIDIA/spark-rapids-examples/issues/258

Depend on https://github.com/NVIDIA/spark-rapids/pull/7377
 
Signed-off-by: Gary Shen <gashen@nvidia.com>