### PR TITLE
Fix UDF test cases failed on Databricks 3.1.2

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/python/asserts.py
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/python/asserts.py
@@ -287,12 +287,12 @@ def assert_gpu_fallback_write(write_func,
     cpu_end = time.time()
     print('### GPU RUN ###')
     jvm = spark_jvm()
-    jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.startCapture()
+    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.startCapture()
     gpu_start = time.time()
     gpu_path = base_path + '/GPU'
     with_gpu_session(lambda spark : write_func(spark, gpu_path), conf=conf)
     gpu_end = time.time()
-    jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertCapturedAndGpuFellBack(cpu_fallback_class_name, 2000)
+    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertCapturedAndGpuFellBack(cpu_fallback_class_name, 10000)
     print('### WRITE: GPU TOOK {} CPU TOOK {} ###'.format(
         gpu_end - gpu_start, cpu_end - cpu_start))
 
@@ -328,10 +328,10 @@ def assert_cpu_and_gpu_are_equal_collect_with_capture(func,
     jvm = spark_jvm()
     if exist_classes:
         for clz in exist_classes.split(','):
-            jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertContains(gpu_df._jdf, clz)
+            jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertContains(gpu_df._jdf, clz)
     if non_exist_classes:
         for clz in non_exist_classes.split(','):
-            jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertNotContain(gpu_df._jdf, clz)
+            jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertNotContain(gpu_df._jdf, clz)
     print('### {}: GPU TOOK {} CPU TOOK {} ###'.format(collect_type,
         gpu_end - gpu_start, cpu_end - cpu_start))
     if should_sort_locally():
@@ -374,7 +374,7 @@ def assert_gpu_fallback_collect(func,
     from_gpu, gpu_df = with_gpu_session(bring_back, conf=conf)
     gpu_end = time.time()
     jvm = spark_jvm()
-    jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertDidFallBack(gpu_df._jdf, cpu_fallback_class_name)
+    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertDidFallBack(gpu_df._jdf, cpu_fallback_class_name)
     print('### {}: GPU TOOK {} CPU TOOK {} ###'.format(collect_type,
         gpu_end - gpu_start, cpu_end - cpu_start))
     if should_sort_locally():

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/python/spark_init_internal.py
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/python/spark_init_internal.py
@@ -31,7 +31,7 @@ def _spark__init():
     _sb = pyspark.sql.SparkSession.builder
     _sb.config('spark.plugins', 'com.nvidia.spark.SQLPlugin') \
             .config("spark.sql.adaptive.enabled", "false") \
-            .config('spark.sql.queryExecutionListeners', 'com.nvidia.spark.rapids.ExecutionPlanCaptureCallback')
+            .config('spark.sql.queryExecutionListeners', 'org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback')
 
     for key, value in os.environ.items():
         if key.startswith('PYSP_TEST_') and key != _DRIVER_ENV:


### PR DESCRIPTION
Closes #268

### Problem
`com.nvidia.spark.rapids.ExecutionPlanCaptureCallback` is renamed to `org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback` on Spark-Rapids repo branch 23.02

### Solution
Should update the package accordingly.

Signed-off-by: Chong Gao <res_life@163.com>