### PR TITLE
Update cuda docker images

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION. All rights reserved.
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM nvidia/cuda:11.0-devel-ubuntu18.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu18.04
 ARG spark_uid=185
 
 # Install java dependencies 

--- a/examples/ML+DL-Examples/Spark-cuML/pca/Dockerfile
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/Dockerfile
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-ARG CUDA_VER=11.5.1
+ARG CUDA_VER=11.8.0
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu20.04
 ARG BRANCH_VER=23.08
 

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # A container that can be used to build UDF native code against libcudf
-ARG CUDA_VERSION=11.5.0
+ARG CUDA_VERSION=11.8.0
 ARG LINUX_VERSION=ubuntu18.04
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}


### PR DESCRIPTION
Update cuda docker images as some CUDA versioned container images will be DELETED from DOCKER HUB.

**The tags for the following CUDA versioned container images will be DELETED from NGC AND DOCKER HUB**

* 11\.7.0
* 11\.6.1
* 11\.6.0
* 11\.5.1
* 11\.5.0
* 11\.4.2
* 11\.4.1
* 11\.4.0
* 11\.3.0
* 11\.2.1
* 11\.2.0
* 10\.2
* 10\.1
* 10\.0
* 9\.2
* 9\.1
* 9\.0
* 8\.0
* 7\.0