### PR TITLE
update PCA demo to a fix spark-rapids plugin version

### DIFF
--- a/examples/ML+DL-Examples/Spark-cuML/pca/Dockerfile
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/Dockerfile
@@ -17,6 +17,7 @@
 
 ARG CUDA_VER=11.8.0
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu20.04
+# Please do not update the BRANCH_VER version
 ARG BRANCH_VER=23.08
 
 RUN apt-get update

--- a/examples/ML+DL-Examples/Spark-cuML/pca/Dockerfile
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG CUDA_VER=11.8.0
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu20.04
-ARG BRANCH_VER=23.10
+ARG BRANCH_VER=23.08
 
 RUN apt-get update
 RUN apt-get install -y wget ninja-build git

--- a/examples/ML+DL-Examples/Spark-cuML/pca/README.md
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/README.md
@@ -14,7 +14,7 @@ User can also download the release jar from Maven central:
 
 [rapids-4-spark_2.12-23.08.1.jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/23.08.1/rapids-4-spark_2.12-23.08.1.jar)
 
-Note: This demo could only work with v22.02.0 version.
+Note: This demo could only work with v22.02.0 spark-ml version, and only compatible with spark-rapids versions prior to 23.08.1 .
 
 ## Sample code
 

--- a/examples/ML+DL-Examples/Spark-cuML/pca/README.md
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/README.md
@@ -14,7 +14,7 @@ User can also download the release jar from Maven central:
 
 [rapids-4-spark_2.12-23.08.1.jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/23.08.1/rapids-4-spark_2.12-23.08.1.jar)
 
-Note: This demo could only work with v22.02.0 spark-ml version, and only compatible with spark-rapids versions prior to 23.08.1 .
+Note: This demo could only work with v22.02.0 spark-ml version, and only compatible with spark-rapids versions prior to 23.08.1 . Please do not update the version in release.
 
 ## Sample code
 

--- a/examples/ML+DL-Examples/Spark-cuML/pca/pom.xml
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.nvidia</groupId>
     <artifactId>PCAExample</artifactId>
     <packaging>jar</packaging>
-    <version>23.10.0-SNAPSHOT</version>
+    <version>23.08.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/examples/ML+DL-Examples/Spark-cuML/pca/pom.xml
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/pom.xml
@@ -52,7 +52,7 @@
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-ml_2.12</artifactId>
             <version>23.04.0-SNAPSHOT</version>
-            <!--The last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT!-->
+            <!--The last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT! Please do not update the version-->
         </dependency>
     </dependencies>
 

--- a/examples/ML+DL-Examples/Spark-cuML/pca/spark-submit.sh
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/spark-submit.sh
@@ -15,8 +15,9 @@
 # limitations under the License.
 #
 
+# Note that the last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT
 ML_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-ml_2.12/23.04.0-SNAPSHOT/rapids-4-spark-ml_2.12-23.04.0-SNAPSHOT.jar
-PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/23.08.0-SNAPSHOT/rapids-4-spark_2.12-23.10.0-SNAPSHOT.jar
+PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/23.08.0-SNAPSHOT/rapids-4-spark_2.12-23.08.0-SNAPSHOT.jar
 Note: The last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT.
 
 $SPARK_HOME/bin/spark-submit \

--- a/examples/ML+DL-Examples/Spark-cuML/pca/spark-submit.sh
+++ b/examples/ML+DL-Examples/Spark-cuML/pca/spark-submit.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# Note that the last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT
+# Note that the last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT, please do not update the version in release
 ML_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark-ml_2.12/23.04.0-SNAPSHOT/rapids-4-spark-ml_2.12-23.04.0-SNAPSHOT.jar
 PLUGIN_JAR=/root/.m2/repository/com/nvidia/rapids-4-spark_2.12/23.08.0-SNAPSHOT/rapids-4-spark_2.12-23.08.0-SNAPSHOT.jar
 Note: The last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT.


### PR DESCRIPTION
Note that the last rapids-4-spark-ml release version is 22.02.0, snapshot version is 23.04.0-SNPASHOT,
and this demo could only work with v22.02.0 spark-ml version, and only compatible with spark-rapids versions prior to 23.08.1 .
