### PR TITLE
Enable ccache in UDF examples build

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -70,3 +70,18 @@ RUN cd /tmp \
  && make install -j${PARALLEL_LEVEL} \
  && cd /tmp && rm -rf /tmp/cmake-$CMAKE_VERSION*
 
+# Install ccache
+ARG CCACHE_VERSION=4.6
+RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
+  tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
+  rm ccache-${CCACHE_VERSION}.tar.gz && \
+  cd ccache-${CCACHE_VERSION} && \
+  mkdir build && \
+  cd build && \
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DZSTD_FROM_INTERNET=ON \
+    -DREDIS_STORAGE_BACKEND=OFF && \
+  cmake --build . --parallel ${PARALLEL_LEVEL} --target install && \
+  cd ../.. && \
+  rm -rf ccache-${CCACHE_VERSION}

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
@@ -144,7 +144,7 @@ mvn clean package -Pudf-native-examples
 ```
 
 The Docker container has installed ccache 4.6 to accelerate the incremental building.
-You can change the LOCAL_CCACHE_DIR to a mounted folder so that the cache can be kept by next docker running.
+You can change the LOCAL_CCACHE_DIR to a mounted folder so that the cache can persist.
 If you don't want to use ccache, you can remove or unset the ccache environment variables.
 
 ```bash

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
@@ -133,11 +133,34 @@ In the Docker container, clone the code and compile.
 ```bash
 git clone https://github.com/NVIDIA/spark-rapids-examples.git
 cd spark-rapids-examples/examples/UDF-Examples/RAPIDS-accelerated-UDFs
+export LOCAL_CCACHE_DIR="$HOME/.ccache"
+mkdir -p $LOCAL_CCACHE_DIR
+export CCACHE_DIR="$LOCAL_CCACHE_DIR"
+export CMAKE_C_COMPILER_LAUNCHER="ccache"
+export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
+export CMAKE_CUDA_COMPILER_LAUNCHER="ccache"
+export CMAKE_CXX_LINKER_LAUNCHER="ccache
 mvn clean package -Pudf-native-examples
 ```
 
-The build could take a long time (e.g.: 1.5 hours). Then the rapids-4-spark-udf-examples*.jar is
+The Docker container has installed ccache 4.6 to accelerate the incremental building.
+You can change the LOCAL_CCACHE_DIR to a mounted folder so that the cache can be kept by next docker running.
+If you don't want to use ccache, you can remove or unset the ccache environment variables.
+
+```bash
+unset CCACHE_DIR
+unset CMAKE_C_COMPILER_LAUNCHER
+unset CMAKE_CXX_COMPILER_LAUNCHER
+unset CMAKE_CUDA_COMPILER_LAUNCHER
+unset CMAKE_CXX_LINKER_LAUNCHER
+```
+
+The first build could take a long time (e.g.: 1.5 hours). Then the rapids-4-spark-udf-examples*.jar is
 generated under RAPIDS-accelerated-UDFs/target directory.
+The following build can benefit from ccache if you enable it.
+
+If you want to enable building with ccache on your own system,
+please refer to the commands which build ccache from the source code in the Dockerfile.
 
 ### Run all the examples including native examples in the docker
 


### PR DESCRIPTION
Install ccache in Dockerfile used to build UDF example.
Update README to explain how to use it by adding some environment variables

close https://github.com/NVIDIA/spark-rapids-examples/issues/343

