### PR TITLE
Support scala 2.13 for xgboost samples

### DIFF
--- a/examples/XGBoost-Examples/agaricus/pom.xml
+++ b/examples/XGBoost-Examples/agaricus/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+  ~ Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/XGBoost-Examples/agaricus/pom.xml
+++ b/examples/XGBoost-Examples/agaricus/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark_examples_agaricus</artifactId>
+    <artifactId>spark_examples_agaricus_${scala.binary.version}</artifactId>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_utility</artifactId>
+            <artifactId>spark_examples_utility_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/examples/XGBoost-Examples/aggregator/pom.xml
+++ b/examples/XGBoost-Examples/aggregator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+  ~ Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/XGBoost-Examples/aggregator/pom.xml
+++ b/examples/XGBoost-Examples/aggregator/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark_examples_aggregator</artifactId>
+    <artifactId>spark_examples_aggregator_${scala.binary.version}</artifactId>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -35,32 +35,32 @@
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_utility</artifactId>
+            <artifactId>spark_examples_utility_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_agaricus</artifactId>
+            <artifactId>spark_examples_agaricus_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_mortgage</artifactId>
+            <artifactId>spark_examples_mortgage_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_taxi</artifactId>
+            <artifactId>spark_examples_taxi_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <finalName>sample_xgboost_apps-${project.version}</finalName>
+        <finalName>sample_xgboost_apps_${scala.binary.version}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/examples/XGBoost-Examples/assembly/assembly-no-scala.xml
+++ b/examples/XGBoost-Examples/assembly/assembly-no-scala.xml
@@ -1,7 +1,7 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-  <id>jar-with-dependencies</id>
+  <id>jar-with-dependencies_${scala.binary.version}</id>
   <formats>
     <format>jar</format>
   </formats>

--- a/examples/XGBoost-Examples/assembly/assembly-no-scala.xml
+++ b/examples/XGBoost-Examples/assembly/assembly-no-scala.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">

--- a/examples/XGBoost-Examples/mortgage/pom.xml
+++ b/examples/XGBoost-Examples/mortgage/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+  ~ Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/XGBoost-Examples/mortgage/pom.xml
+++ b/examples/XGBoost-Examples/mortgage/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark_examples_mortgage</artifactId>
+    <artifactId>spark_examples_mortgage_${scala.binary.version}</artifactId>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_utility</artifactId>
+            <artifactId>spark_examples_utility_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/examples/XGBoost-Examples/pom.xml
+++ b/examples/XGBoost-Examples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  ~ Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+  ~ Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/XGBoost-Examples/pom.xml
+++ b/examples/XGBoost-Examples/pom.xml
@@ -38,8 +38,8 @@
 
     <properties>
         <encoding>UTF-8</encoding>
-        <xgboost.version>2.0.0</xgboost.version>
-        <spark.version>3.1.1</spark.version>
+        <xgboost.version>2.0.3</xgboost.version>
+        <spark.version>3.5.0</spark.version>
         <scala.version>2.12.8</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
     </properties>
@@ -47,12 +47,12 @@
     <dependencies>
         <dependency>
             <groupId>ml.dmlc</groupId>
-            <artifactId>xgboost4j-gpu_2.12</artifactId>
+            <artifactId>xgboost4j-gpu_${scala.binary.version}</artifactId>
             <version>${xgboost.version}</version>
         </dependency>
         <dependency>
             <groupId>ml.dmlc</groupId>
-            <artifactId>xgboost4j-spark-gpu_2.12</artifactId>
+            <artifactId>xgboost4j-spark-gpu_${scala.binary.version}</artifactId>
             <version>${xgboost.version}</version>
         </dependency>
         <dependency>
@@ -133,6 +133,15 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <xgboost.version>2.1.0-SNAPSHOT</xgboost.version>
+                <spark.version>3.5.0</spark.version>
+                <scala.version>2.13.11</scala.version>
+                <scala.binary.version>2.13</scala.binary.version>
+            </properties>
+        </profile>
         <profile>
             <id>sonatype-repo</id>
             <repositories>

--- a/examples/XGBoost-Examples/taxi/pom.xml
+++ b/examples/XGBoost-Examples/taxi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+  ~ Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/XGBoost-Examples/taxi/pom.xml
+++ b/examples/XGBoost-Examples/taxi/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark_examples_taxi</artifactId>
+    <artifactId>spark_examples_taxi_${scala.binary.version}</artifactId>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>spark_examples_utility</artifactId>
+            <artifactId>spark_examples_utility_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/examples/XGBoost-Examples/utility/pom.xml
+++ b/examples/XGBoost-Examples/utility/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+  ~ Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/XGBoost-Examples/utility/pom.xml
+++ b/examples/XGBoost-Examples/utility/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark_examples_utility</artifactId>
+    <artifactId>spark_examples_utility_${scala.binary.version}</artifactId>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION
This PR adds scala version for the artifactId to distinguish the scala 2.12 and scala 2.13.

To compile xgboost samples against scala 2.13, you can use below command

``` bash
mvn clean package -P scala-2.13
```