### PR TITLE
Revert CUDA static runtime change from main

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
@@ -192,10 +192,11 @@ schema = StructType([
     StructField("c2", IntegerType()),
 ])
 data = [
-    ("a b c d",1),
-    ("",2),
-    (None,3),
-    ("the quick brown fox jumped over the lazy dog",3),
+    ("s1",1),
+    ("s2",2),
+    ("s1",3),
+    ("s2",3),
+    ("s1",3),
 ]
 df = spark.createDataFrame(
         SparkContext.getOrCreate().parallelize(data, numSlices=2),
@@ -203,6 +204,6 @@ df = spark.createDataFrame(
 df.createOrReplaceTempView("tab")
 
 spark.sql("CREATE TEMPORARY FUNCTION {} AS '{}'".format("wordcount", "com.nvidia.spark.rapids.udf.hive.StringWordCount"))
-spark.sql("select c1, wordcount(c1) from tab").show()
-spark.sql("select c1, wordcount(c1) from tab").explain()
+spark.sql("select wordcount(c1) from tab group by c1").show()
+spark.sql("select wordcount(c1) from tab group by c1").explain()
 ```

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 # - cudf -------------------------------------------------------------------------------------------
 
 # Ensure CUDA runtime is dynamic despite statically linking Arrow in libcudf
-set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
+set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
 rapids_cpm_init()
 rapids_cpm_find(cudf 23.12.00
@@ -94,7 +94,7 @@ rapids_cpm_find(cudf 23.12.00
                         "BUILD_BENCHMARKS OFF"
                         "CUDF_USE_ARROW_STATIC ON"
                         "JITIFY_USE_CACHE ON"
-                        "CUDA_STATIC_RUNTIME ${CUDA_USE_STATIC_CUDA_RUNTIME}"
+                        "CUDA_STATIC_RUNTIME OFF"
                         "DISABLE_DEPRECATION_WARNING ON"
                         "AUTO_DETECT_CUDA_ARCHITECTURES OFF"
     )


### PR DESCRIPTION
This reverts #347 which should have targeted branch-24.02 instead of main.