### PR TITLE
Fix invalid param value "use_gpu":"true"

### DIFF
--- a/examples/XGBoost-Examples/agaricus/notebooks/python/agaricus-gpu.ipynb
+++ b/examples/XGBoost-Examples/agaricus/notebooks/python/agaricus-gpu.ipynb
@@ -197,7 +197,7 @@
     "    \"tree_method\": \"gpu_hist\",\n",
     "    \"grow_policy\": \"depthwise\",\n",
     "    \"num_workers\": 1,\n",
-    "    \"use_gpu\": \"true\",\n",
+    "    \"device\": \"cuda\",\n",
     "}\n",
     "params['features_col'] = features\n",
     "params['label_col'] = label\n",

--- a/examples/XGBoost-Examples/mortgage/notebooks/python/MortgageETL+XGBoost.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/python/MortgageETL+XGBoost.ipynb
@@ -933,7 +933,7 @@
     "    \"tree_method\": \"gpu_hist\",\n",
     "    \"grow_policy\": \"depthwise\",\n",
     "    \"num_workers\": 1,\n",
-    "    \"use_gpu\": \"true\",\n",
+    "    \"device\": \"cuda\",\n",
     "}\n",
     "params['features_col'] = features\n",
     "params['label_col'] = label\n",

--- a/examples/XGBoost-Examples/mortgage/notebooks/python/cv-mortgage-gpu.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/python/cv-mortgage-gpu.ipynb
@@ -191,7 +191,7 @@
     "    \"tree_method\": \"gpu_hist\",\n",
     "    \"grow_policy\": \"depthwise\",\n",
     "    \"num_workers\": 1,\n",
-    "    \"use_gpu\": \"true\",\n",
+    "    \"device\": \"cuda\",\n",
     "}\n",
     "\n",
     "params['features_col'] = features\n",

--- a/examples/XGBoost-Examples/mortgage/notebooks/python/mortgage-gpu.ipynb
+++ b/examples/XGBoost-Examples/mortgage/notebooks/python/mortgage-gpu.ipynb
@@ -235,7 +235,7 @@
     "    \"tree_method\": \"gpu_hist\",\n",
     "    \"grow_policy\": \"depthwise\",\n",
     "    \"num_workers\": 1,\n",
-    "    \"use_gpu\": \"true\",\n",
+    "    \"device\": \"cuda\",\n",
     "}\n",
     "params['features_col'] = features\n",
     "params['label_col'] = label\n",

--- a/examples/XGBoost-Examples/taxi/notebooks/python/cv-taxi-gpu.ipynb
+++ b/examples/XGBoost-Examples/taxi/notebooks/python/cv-taxi-gpu.ipynb
@@ -182,7 +182,7 @@
     "    \"tree_method\": \"gpu_hist\",\n",
     "    \"grow_policy\": \"depthwise\",\n",
     "    \"num_workers\": 1,\n",
-    "    \"use_gpu\": \"true\",\n",
+    "    \"device\": \"cuda\",\n",
     "}\n",
     "params['features_col'] = features\n",
     "params['label_col'] = label\n",

--- a/examples/XGBoost-Examples/taxi/notebooks/python/taxi-gpu.ipynb
+++ b/examples/XGBoost-Examples/taxi/notebooks/python/taxi-gpu.ipynb
@@ -213,7 +213,7 @@
     "    \"tree_method\": \"gpu_hist\",\n",
     "    \"grow_policy\": \"depthwise\",\n",
     "    \"num_workers\": 1,\n",
-    "    \"use_gpu\": \"true\",\n",
+    "    \"device\": \"cuda\",\n",
     "}\n",
     "params['features_col'] = features\n",
     "params['label_col'] = label\n",


### PR DESCRIPTION
After installing latest Jupyter notebooke, the json format check is strick, due to passing a string value "true"

for the "use_gpu":"true", "use_gpu": True is required.

```
params = {
    "tree_method": "gpu_hist",
    "grow_policy": "depthwise",
    "num_workers": 1,
    "use_gpu": "true", -->  "device": "cuda"
}
```
TypeError: Invalid param value given for param "use_gpu".

Boolean Param requires value of type bool. Found <class 'str'>.

More over, "use_gpu": True is deprecated in dmlc/XGBoost, change to user "device": "cuda" instead