### PR TITLE
[auto-merge] branch-24.06 to branch-24.08 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-24.04
+    - branch-24.06
     types: [closed]
 
 jobs:
@@ -29,14 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: branch-24.04 # force to fetch from latest upstream instead of PR ref
+          ref: branch-24.06 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids-examples
-          HEAD: branch-24.04
-          BASE: branch-24.06
+          HEAD: branch-24.06
+          BASE: branch-24.08
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR
 


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-24.06` to create a PR keeping `branch-24.08` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.