### PR TITLE
Disable kvikio remote I/O to avoid openssl dependencies in cudf build

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -97,6 +97,7 @@ rapids_cpm_find(cudf 24.12.00
                         "CUDA_STATIC_RUNTIME ${CUDA_USE_STATIC_CUDA_RUNTIME}"
                         "DISABLE_DEPRECATION_WARNING ON"
                         "AUTO_DETECT_CUDA_ARCHITECTURES OFF"
+                        "KvikIO_REMOTE_SUPPORT OFF"
     )
 
 ###################################################################################################


### PR DESCRIPTION
```
15:42:45  [INFO]      [exec] -- Configuring incomplete, errors occurred!
15:42:45  [INFO]      [exec] CMake Error at /usr/local/cmake-3.26.4-linux-x86_64/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
15:42:45  [INFO]      [exec]   Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
15:42:45  [INFO]      [exec]   system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
15:42:45  [INFO]      [exec]   OPENSSL_INCLUDE_DIR)
15:42:45  [INFO]      [exec] Call Stack (most recent call first):
15:42:45  [INFO]      [exec]   /usr/local/cmake-3.26.4-linux-x86_64/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
15:42:45  [INFO]      [exec]   /usr/local/cmake-3.26.4-linux-x86_64/share/cmake-3.26/Modules/FindOpenSSL.cmake:670 (find_package_handle_standard_args)
15:42:45  [INFO]      [exec]   /home/jenkins/agent/workspace/jenkins-examples-udf-examples-native-169/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/cpp-build/_deps/curl-src/CMakeLists.txt:449 (find_package)
15:42:45  [INFO]      [exec] 
```
port the fix https://github.com/rapidsai/cudf/pull/17026 to UDF-native build