### PR TITLE
Update udf native example cmake version to 3.28.6

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -41,7 +41,7 @@ RUN dnf --enablerepo=powertools install -y \
   && alternatives --set python /usr/bin/python3
 
 # 3.22.3: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
-ARG CMAKE_VERSION=3.26.4
+ARG CMAKE_VERSION=3.28.6
 # default x86_64 from x86 build, aarch64 cmake for arm build
 ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.12/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)


### PR DESCRIPTION
To port the cmake update for JNI from cudf side

This has been verified internally, passed both build and test cases
```
[exec] -- Building using CMake version: 3.28.6
```