### PR TITLE
Fix torch-tensorrt install, libstdc++ troubleshooting

### DIFF
--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/README.md
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/README.md
@@ -105,6 +105,10 @@ If you encounter issues starting the Triton server, you may need to link your li
 ```shell
 ln -sf /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ${CONDA_PREFIX}/lib/libstdc++.so.6
 ```
+If the issue persists with the message `libstdc++.so.6: version 'GLIBCXX_3.4.30' not found`, you may need to update libstdc++ in your conda environment:
+```shell
+conda install -c conda-forge libstdcxx-ng
+```
 
 ## Running on Cloud Environments
 

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/README.md
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/README.md
@@ -63,13 +63,13 @@ Each notebook has a suffix `_torch` or `_tf` specifying the environment used.
 
 **For PyTorch:**
 ```
-conda create -n spark-dl-torch python=3.11
+conda create -n spark-dl-torch -c conda-forge python=3.11
 conda activate spark-dl-torch
 pip install -r torch_requirements.txt
 ```
 **For TensorFlow:**
 ```
-conda create -n spark-dl-tf python=3.11
+conda create -n spark-dl-tf -c conda-forge python=3.11
 conda activate spark-dl-tf
 pip install -r tf_requirements.txt
 ```

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/setup/init_spark_dl.sh
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/setup/init_spark_dl.sh
@@ -12,7 +12,7 @@ datasets==3.*
 transformers
 urllib3<2
 nvidia-pytriton
-torch
+torch<=2.5.1
 torchvision --extra-index-url https://download.pytorch.org/whl/cu121
 torch-tensorrt
 tensorrt --extra-index-url https://download.pytorch.org/whl/cu121

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/dataproc/setup/start_cluster.sh
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/dataproc/setup/start_cluster.sh
@@ -49,7 +49,7 @@ urllib3<2
 nvidia-pytriton"
 
 TORCH_REQUIREMENTS="${COMMON_REQUIREMENTS}
-torch
+torch<=2.5.1
 torchvision --extra-index-url https://download.pytorch.org/whl/cu121
 torch-tensorrt
 tensorrt --extra-index-url https://download.pytorch.org/whl/cu121

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/requirements.txt
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/requirements.txt
@@ -26,6 +26,5 @@ huggingface
 datasets
 transformers
 ipywidgets
-ipykernel
 urllib3<2
 nvidia-pytriton

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/torch_requirements.txt
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/torch_requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/torch_requirements.txt
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/torch_requirements.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -r requirements.txt
-torch
+torch<=2.5.1
 torchvision
 torch-tensorrt
 tensorrt --extra-index-url https://download.pytorch.org/whl/cu121


### PR DESCRIPTION
Pin torch<=2.5.1 until torch-tensorrt has a compatible version for torch 2.6.
Add troubleshooting to update libstdc++ for Triton server binary requirements; can occur if default conda channel is used and not up to date.
Removed ipykernel from requirements since it's already pulled in by jupyterlab (and slows pip down a lot). 