### PR TITLE
Update urllib3 requirement and cleanup instructions

### DIFF
--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/README.md
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/README.md
@@ -69,19 +69,21 @@ Each notebook has a suffix `_torch` or `_tf` specifying the environment used.
 ```
 conda create -n spark-dl-torch -c conda-forge python=3.11
 conda activate spark-dl-torch
+conda install -c conda-forge libstdcxx-ng
 pip install -r torch_requirements.txt
 ```
 **For TensorFlow:**
 ```
 conda create -n spark-dl-tf -c conda-forge python=3.11
 conda activate spark-dl-tf
+conda install -c conda-forge libstdcxx-ng
 pip install -r tf_requirements.txt
 ```
 
 #### Start Cluster
 
 For demonstration, these instructions just use a local Standalone cluster with a single executor, but they can be run on any distributed Spark cluster. For cloud environments, see [below](#running-on-cloud-environments).
-
+If you haven't already, [install Spark](https://spark.apache.org/downloads.html) on your system. 
 ```shell
 # Replace with your Spark installation path
 export SPARK_HOME=</path/to/spark>
@@ -113,10 +115,6 @@ The notebooks are ready to run! Each notebook has a cell to connect to the stand
 If you encounter issues starting the Triton server, you may need to link your libstdc++ file to the conda environment, e.g.:
 ```shell
 ln -sf /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ${CONDA_PREFIX}/lib/libstdc++.so.6
-```
-If the issue persists with the message `libstdc++.so.6: version 'GLIBCXX_3.4.30' not found`, you may need to update libstdc++ in your conda environment:
-```shell
-conda install -c conda-forge libstdcxx-ng
 ```
 
 ## Running on Cloud Environments

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/README.md
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/README.md
@@ -1,6 +1,7 @@
 # Spark DL Inference on Databricks
 
-**Note**: fields in \<brackets\> require user inputs.
+**Note**: fields in \<brackets\> require user inputs.  
+Make sure you are in [this](./) directory.
 
 ## Setup
 
@@ -9,16 +10,19 @@
 2. Specify the path to your Databricks workspace:
     ```shell
     export WS_PATH=</Users/someone@example.com>
+    ```
 
-    export NOTEBOOK_DEST=${WS_PATH}/spark-dl/notebook_torch.ipynb
-    export UTILS_DEST=${WS_PATH}/spark-dl/pytriton_utils.py
-    export INIT_DEST=${WS_PATH}/spark-dl/init_spark_dl.sh
+    ```shell
+    export SPARK_DL_WS=${WS_PATH}/spark-dl
+    databricks workspace mkdirs ${SPARK_DL_WS}
     ```
 3. Specify the local paths to the notebook you wish to run, the utils file, and the init script.
     As an example for a PyTorch notebook:
     ```shell
     export NOTEBOOK_SRC=</path/to/notebook_torch.ipynb>
-    export UTILS_SRC=</path/to/pytriton_utils.py>
+    ```
+    ```shell
+    export UTILS_SRC=$(realpath ../pytriton_utils.py)
     export INIT_SRC=$(pwd)/setup/init_spark_dl.sh
     ```
 4. Specify the framework to torch or tf, corresponding to the notebook you wish to run. Continuing with the PyTorch example:
@@ -29,9 +33,9 @@
 
 5. Copy the files to the Databricks Workspace:
     ```shell
-    databricks workspace import $NOTEBOOK_DEST --format JUPYTER --file $NOTEBOOK_SRC
-    databricks workspace import $UTILS_DEST --format AUTO --file $UTILS_SRC
-    databricks workspace import $INIT_DEST --format AUTO --file $INIT_SRC
+    databricks workspace import ${SPARK_DL_WS}/notebook_torch.ipynb --format JUPYTER --file $NOTEBOOK_SRC
+    databricks workspace import ${SPARK_DL_WS}/pytriton_utils.py --format AUTO --file $UTILS_SRC
+    databricks workspace import ${SPARK_DL_WS}/init_spark_dl.sh --format AUTO --file $INIT_SRC
     ```
 
 6. Launch the cluster with the provided script. By default the script will create a cluster with 4 A10 worker nodes and 1 A10 driver node. (Note that the script uses **Azure instances** by default; change as needed).

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/setup/init_spark_dl.sh
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/setup/init_spark_dl.sh
@@ -10,7 +10,6 @@ if [[ "${FRAMEWORK}" == "torch" ]]; then
     cat <<EOF > temp_requirements.txt
 datasets==3.*
 transformers
-urllib3<2
 nvidia-pytriton
 torch<=2.5.1
 torchvision --extra-index-url https://download.pytorch.org/whl/cu121
@@ -24,7 +23,6 @@ elif [[ "${FRAMEWORK}" == "tf" ]]; then
     cat <<EOF > temp_requirements.txt
 datasets==3.*
 transformers
-urllib3<2
 nvidia-pytriton
 EOF
 else

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/setup/start_cluster.sh
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/databricks/setup/start_cluster.sh
@@ -26,7 +26,7 @@ json_config=$(cat <<EOF
         "spark.python.worker.reuse": "true",
         "spark.sql.execution.arrow.pyspark.enabled": "true",
         "spark.task.resource.gpu.amount": "0.16667",
-        "spark.executor.cores": "6"
+        "spark.executor.cores": "12"
     },
     "node_type_id": "Standard_NV12ads_A10_v5",
     "driver_node_type_id": "Standard_NV12ads_A10_v5",

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/dataproc/README.md
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/dataproc/README.md
@@ -2,7 +2,8 @@
 
 ## Setup
 
-**Note**: fields in \<brackets\> require user inputs.
+**Note**: fields in \<brackets\> require user inputs.  
+Make sure you are in [this](./) directory.
 
 #### Setup GCloud CLI
 
@@ -41,7 +42,7 @@
 
 5. Copy the utils file to the GCS bucket.
     ```shell
-    gcloud storage cp </path/to/pytriton_utils.py> gs://${SPARK_DL_HOME}/
+    gcloud storage cp $(realpath ../pytriton_utils.py) gs://${SPARK_DL_HOME}/
     ```
 
 #### Start cluster and run

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/dataproc/setup/start_cluster.sh
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/dataproc/setup/start_cluster.sh
@@ -45,7 +45,6 @@ scikit-learn
 huggingface
 datasets==3.*
 transformers
-urllib3<2
 nvidia-pytriton"
 
 TORCH_REQUIREMENTS="${COMMON_REQUIREMENTS}

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/requirements.txt
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/requirements.txt
@@ -26,5 +26,4 @@ huggingface
 datasets
 transformers
 ipywidgets
-urllib3<2
 nvidia-pytriton


### PR DESCRIPTION
- Pin of urllib3<2 was an artifact from the old Databricks runtime we were using and is no longer needed. Unpinning allows the latest pytriton to be used. 
- Install libstdcxx by default since latest PyTriton requires 3.4.30
- While testing on CSPs, cleaned up/fixed some instructions. 