### PR TITLE
Infer number of executors / executor resources for PyTriton

### DIFF
--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/conditional_generation_tf.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/conditional_generation_tf.ipynb
@@ -1092,26 +1092,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96b35b50",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "7c4855ca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4142ebfc",
    "metadata": {},
    "source": [
@@ -1129,7 +1109,7 @@
    "outputs": [],
    "source": [
     "model_name = \"ConditionalGeneration\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name)"
+    "server_manager = TritonServerManager(model_name=model_name)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/conditional_generation_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/conditional_generation_torch.ipynb
@@ -1217,24 +1217,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The `TritonClusterManager` will handle the lifecycle of Triton server instances across the Spark cluster:\n",
     "- Find available ports for HTTP/gRPC/metrics\n",
     "- Deploy a server on each node via stage-level scheduling\n",
@@ -1260,7 +1242,7 @@
    "outputs": [],
    "source": [
     "model_name = \"ConditionalGeneration\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name)"
+    "server_manager = TritonServerManager(model_name=model_name)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/deepseek-r1_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/deepseek-r1_torch.ipynb
@@ -528,24 +528,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The `TritonClusterManager` will handle the lifecycle of Triton server instances across the Spark cluster:\n",
     "- Find available ports for HTTP/gRPC/metrics\n",
     "- Deploy a server on each node via stage-level scheduling\n",
@@ -559,7 +541,7 @@
    "outputs": [],
    "source": [
     "model_name = \"deepseek-r1\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/gemma-7b_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/gemma-7b_torch.ipynb
@@ -509,24 +509,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The `TritonClusterManager` will handle the lifecycle of Triton server instances across the Spark cluster:\n",
     "- Find available ports for HTTP/gRPC/metrics\n",
     "- Deploy a server on each node via stage-level scheduling\n",
@@ -540,7 +522,7 @@
    "outputs": [],
    "source": [
     "model_name = \"gemma-7b\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/pipelines_tf.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/pipelines_tf.ipynb
@@ -892,26 +892,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f85dc27",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "id": "714e6ef9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "5354c597",
    "metadata": {},
    "source": [
@@ -929,7 +909,7 @@
    "outputs": [],
    "source": [
     "model_name = \"SentimentAnalysis\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name)"
+    "server_manager = TritonServerManager(model_name=model_name)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/pipelines_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/pipelines_torch.ipynb
@@ -745,26 +745,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5463c517",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "id": "a4757163",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "b5ef160a",
    "metadata": {},
    "source": [
@@ -782,7 +762,7 @@
    "outputs": [],
    "source": [
     "model_name = \"SentimentAnalysis\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name)"
+    "server_manager = TritonServerManager(model_name=model_name)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/qwen-2.5-7b_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/qwen-2.5-7b_torch.ipynb
@@ -593,24 +593,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The `TritonClusterManager` will handle the lifecycle of Triton server instances across the Spark cluster:\n",
     "- Find available ports for HTTP/gRPC/metrics\n",
     "- Deploy a server on each node via stage-level scheduling\n",
@@ -624,7 +606,7 @@
    "outputs": [],
    "source": [
     "model_name = \"qwen-2.5\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/sentence_transformers_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/huggingface/sentence_transformers_torch.ipynb
@@ -657,26 +657,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bef23176",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "b992802e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1b0371c8",
    "metadata": {},
    "source": [
@@ -694,7 +674,7 @@
    "outputs": [],
    "source": [
     "model_name = \"SentenceTransformer\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name)"
+    "server_manager = TritonServerManager(model_name=model_name)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/pytorch/housing_regression_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/pytorch/housing_regression_torch.ipynb
@@ -1437,26 +1437,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbcca988",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "id": "160a0460",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "6d6b7143",
    "metadata": {},
    "source": [
@@ -1474,7 +1454,7 @@
    "outputs": [],
    "source": [
     "model_name = \"HousingModel\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/pytorch/image_classification_torch.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/pytorch/image_classification_torch.ipynb
@@ -2197,26 +2197,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cbca940",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
-   "id": "a63d19bc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The `TritonClusterManager` will handle the lifecycle of Triton server instances across the Spark cluster:\n",
@@ -2233,7 +2213,7 @@
    "outputs": [],
    "source": [
     "model_name = \"ImageClassifier\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/pytriton_utils.py
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/pytriton_utils.py
@@ -185,15 +185,18 @@ class TritonServerManager:
         Initialize the Triton server manager.
 
         Args:
-            num_nodes: Number of executors (GPUs) in cluster
             model_name: Name of the model to serve
             model_path: Optional path to model file for server function to load from disk
         """
         self.spark = SparkSession.getActiveSession()
-        self.num_nodes = num_nodes
+        self.num_nodes = self._get_num_nodes()
         self.model_name = model_name
         self.model_path = model_path
         self._server_pids_ports: Dict[str, Tuple[int, List[int]]] = {}
+
+    def _get_num_nodes(self) -> int:
+        """Get the number of executors in the cluster."""
+        return len([executor.host() for executor in self.spark._jsc.sc().statusTracker().getExecutorInfos()]) - 1
 
     @property
     def host_to_http_url(self) -> Dict[str, str]:
@@ -225,20 +228,18 @@ class TritonServerManager:
         node_rdd = sc.parallelize(list(range(self.num_nodes)), self.num_nodes)
         return self._use_stage_level_scheduling(node_rdd)
 
-    def _use_stage_level_scheduling(self, rdd: RDD, task_gpus: float = 1.0) -> RDD:
+    def _use_stage_level_scheduling(self, rdd: RDD) -> RDD:
         """
-        Use stage-level scheduling to ensure each Triton server instance maps to 1 GPU (executor).
+        Use stage-level scheduling to ensure each Triton server instance maps to 1 executor.
         From https://github.com/NVIDIA/spark-rapids-ml/blob/main/python/src/spark_rapids_ml/core.py
         """
+        from pyspark.resource.profile import ResourceProfileBuilder
+        from pyspark.resource.requests import TaskResourceRequests
+        
         executor_cores = self.spark.conf.get("spark.executor.cores")
         assert executor_cores is not None, "spark.executor.cores is not set"
         executor_gpus = self.spark.conf.get("spark.executor.resource.gpu.amount")
-        assert (
-            executor_gpus is not None and int(executor_gpus) == 1
-        ), "spark.executor.resource.gpu.amount must be set and = 1"
-
-        from pyspark.resource.profile import ResourceProfileBuilder
-        from pyspark.resource.requests import TaskResourceRequests
+        assert executor_gpus is not None, "spark.executor.resource.gpu.amount is not set"
 
         spark_plugins = self.spark.conf.get("spark.plugins", " ")
         assert spark_plugins is not None
@@ -253,6 +254,8 @@ class TritonServerManager:
             and "true" == spark_rapids_sql_enabled.lower()
             else (int(executor_cores) // 2) + 1
         )
+        task_gpus = float(executor_gpus)
+
         treqs = TaskResourceRequests().cpus(task_cores).resource("gpu", task_gpus)
         rp = ResourceProfileBuilder().require(treqs).build
         logger.info(

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/image_classification_tf.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/image_classification_tf.ipynb
@@ -2105,26 +2105,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "629541a2",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "id": "36374a82",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "2695d9ab",
    "metadata": {},
    "source": [
@@ -2142,7 +2122,7 @@
    "outputs": [],
    "source": [
     "model_name = \"ImageClassifier\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/keras_preprocessing_tf.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/keras_preprocessing_tf.ipynb
@@ -1551,26 +1551,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08095b39",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "id": "1d8c358a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "fc93a43a",
    "metadata": {},
    "source": [
@@ -1588,7 +1568,7 @@
    "outputs": [],
    "source": [
     "model_name = \"PetClassifier\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=model_path)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/keras_resnet50_tf.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/keras_resnet50_tf.ipynb
@@ -953,26 +953,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44a387dc",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "132fbfed",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4bf99bde",
    "metadata": {},
    "source": [
@@ -990,7 +970,7 @@
    "outputs": [],
    "source": [
     "model_name = \"ResNet50\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name)"
+    "server_manager = TritonServerManager(model_name=model_name)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/text_classification_tf.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/tensorflow/text_classification_tf.ipynb
@@ -1811,26 +1811,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bad219c9",
-   "metadata": {},
-   "source": [
-    "**Specify the number of nodes in the cluster.**  \n",
-    "Following the README, the example standalone cluster uses 1 node. The example Databricks/Dataproc cluster scripts use 4 nodes by default. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "id": "a01c6198",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change based on cluster setup\n",
-    "num_nodes = 1 if on_standalone else 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "fcdb7c5a",
    "metadata": {},
    "source": [
@@ -1848,7 +1828,7 @@
    "outputs": [],
    "source": [
     "model_name = \"TextModel\"\n",
-    "server_manager = TritonServerManager(num_nodes=num_nodes, model_name=model_name, model_path=triton_model_path)"
+    "server_manager = TritonServerManager(model_name=model_name, model_path=triton_model_path)"
    ]
   },
   {


### PR DESCRIPTION
Infer number of executors, providing "num_nodes" is no longer needed.
Avoid hardcoding 1 GPU per exec to prepare for tensor-parallel examples. 