### PR TITLE
Adding Programmatic Tools Version Configuration to Databricks Notebooks

### DIFF
--- a/tools/databricks/[RAPIDS Accelerator for Apache Spark] Profiling Tool Notebook Template.ipynb
+++ b/tools/databricks/[RAPIDS Accelerator for Apache Spark] Profiling Tool Notebook Template.ipynb
@@ -53,7 +53,9 @@
    },
    "outputs": [],
    "source": [
-    "TOOLS_VER = \"25.02.1\"\n",
+    "DEFAULT_TOOLS_VER = \"24.12.4\"\n",
+    "TOOLS_VER_ARG = dbutils.widgets.get(\"Tools Version\")\n",
+    "TOOLS_VER = TOOLS_VER_ARG if TOOLS_VER_ARG else DEFAULT_TOOLS_VER\n",
     "print(f\"Using Tools Version: {TOOLS_VER}\")"
    ]
   },
@@ -514,15 +516,15 @@
      "nuid": "1272501d-5ad9-42be-ab62-35768b2fc384",
      "typedWidgetInfo": null,
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "/dbfs/user1/profiling_logs",
       "label": "",
       "name": "Eventlog Path",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "Output Path": {
@@ -530,15 +532,15 @@
      "nuid": "ab7e082c-1ef9-4912-8fd7-51bf985eb9c1",
      "typedWidgetInfo": null,
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "/tmp",
       "label": null,
       "name": "Output Path",
       "options": {
-       "widgetType": "text",
        "autoCreated": null,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     }
    }

--- a/tools/databricks/[RAPIDS Accelerator for Apache Spark] Qualification Tool Notebook Template.ipynb
+++ b/tools/databricks/[RAPIDS Accelerator for Apache Spark] Qualification Tool Notebook Template.ipynb
@@ -49,7 +49,9 @@
    },
    "outputs": [],
    "source": [
-    "TOOLS_VER = \"25.02.1\"\n",
+    "DEFAULT_TOOLS_VER = \"24.12.4\"\n",
+    "TOOLS_VER_ARG = dbutils.widgets.get(\"Tools Version\")\n",
+    "TOOLS_VER = TOOLS_VER_ARG if TOOLS_VER_ARG else DEFAULT_TOOLS_VER\n",
     "print(f\"Using Tools Version: {TOOLS_VER}\")"
    ]
   },
@@ -714,15 +716,15 @@
      "nuid": "1272501d-5ad9-42be-ab62-35768b2fc384",
      "typedWidgetInfo": null,
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "/dbfs/user1/qualification_logs",
       "label": "",
       "name": "Eventlog Path",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "Output Path": {
@@ -730,15 +732,15 @@
      "nuid": "ab7e082c-1ef9-4912-8fd7-51bf985eb9c1",
      "typedWidgetInfo": null,
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "/tmp",
       "label": null,
       "name": "Output Path",
       "options": {
-       "widgetType": "text",
        "autoCreated": null,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     }
    }


### PR DESCRIPTION
Fixes #517 

We need to improve our Databricks Qualification and Profiling Quick Start Notebooks to support programmatic specification of the Tools Version. This is a prerequisite for automating Tools Versions used in these notebooks.

### Result

1. Tools Version from Databricks API:

<img width="412" alt="image" src="https://github.com/user-attachments/assets/122a4404-1aa2-4b66-ae56-e8de529af291" />

2. Tools Version used in the Notebook:
<img width="859" alt="image" src="https://github.com/user-attachments/assets/2644702c-1e77-48d5-9409-254346efee7d" />
