### PR TITLE
Fix unloading of vLLM model from GPU

### DIFF
--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/server_utils.py
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/server_utils.py
@@ -303,7 +303,7 @@ class ServerManager:
             return None
 
         return {
-            host: f"http://{host}:{ports[0]}"
+            host: f"http://localhost:{ports[0]}"
             for host, (_, ports) in self._server_pids_ports.items()
         }
 
@@ -467,7 +467,7 @@ class TritonServerManager(ServerManager):
             return None
 
         return {
-            host: f"grpc://{host}:{ports[1]}"
+            host: f"grpc://localhost:{ports[1]}"
             for host, (_, ports) in self._server_pids_ports.items()
         }
 

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
@@ -223,12 +223,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import contextlib\n",
     "import gc\n",
     "import torch\n",
+    "from vllm.distributed import destroy_model_parallel, destroy_distributed_environment\n",
+    "\n",
+    "def cleanup():\n",
+    "    destroy_model_parallel()\n",
+    "    destroy_distributed_environment()\n",
+    "    with contextlib.supress(AssertionError):\n",
+    "        torch.distributed.destroy_process_group()\n",
+    "    gc.collect()\n",
+    "    torch.cuda.empty_cache()\n",
+    "\n",
     "del llm\n",
-    "torch.distributed.destroy_process_group()\n",
-    "gc.collect()\n",
-    "torch.cuda.empty_cache()"
+    "cleanup()"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
@@ -228,16 +228,16 @@
     "import torch\n",
     "from vllm.distributed import destroy_model_parallel, destroy_distributed_environment\n",
     "\n",
-    "def cleanup():\n",
+    "def cleanup(llm):\n",
     "    destroy_model_parallel()\n",
     "    destroy_distributed_environment()\n",
-    "    with contextlib.supress(AssertionError):\n",
+    "    with contextlib.suppress(AssertionError):\n",
     "        torch.distributed.destroy_process_group()\n",
+    "    del llm\n",
     "    gc.collect()\n",
     "    torch.cuda.empty_cache()\n",
     "\n",
-    "del llm\n",
-    "cleanup()"
+    "cleanup(llm)"
    ]
   },
   {

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
@@ -218,6 +218,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unload the model to free up the GPU for the PySpark section."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
+++ b/examples/ML+DL-Examples/Spark-DL/dl_inference/vllm/qwen-2.5-7b_vllm.ipynb
@@ -228,16 +228,16 @@
     "import torch\n",
     "from vllm.distributed import destroy_model_parallel, destroy_distributed_environment\n",
     "\n",
-    "def cleanup(llm):\n",
+    "def cleanup():\n",
     "    destroy_model_parallel()\n",
     "    destroy_distributed_environment()\n",
     "    with contextlib.suppress(AssertionError):\n",
     "        torch.distributed.destroy_process_group()\n",
-    "    del llm\n",
     "    gc.collect()\n",
     "    torch.cuda.empty_cache()\n",
     "\n",
-    "cleanup(llm)"
+    "del llm\n",
+    "cleanup()"
    ]
   },
   {


### PR DESCRIPTION
Follows [vLLM #6554 comment](https://github.com/vllm-project/vllm/issues/6544#issuecomment-2237994380) to properly release vLLM model from GPU memory.
(Particularly, vLLM now wraps/releases the torch process group, so the old code was raising an assertion error). 