### PR TITLE
Fix no rapids cmake version

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -14,7 +14,11 @@
 # limitations under the License.
 #=============================================================================
 
+# Keep the same with https://github.com/NVIDIA/spark-rapids-jni/blob/main/src/branch-xx.xx/cpp/CMakeLists.txt
+# the branch-xx.xx in the above line is the branch version
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+
+# set to the cuDF version
 set(rapids-cmake-version "25.06")
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-25.06/RAPIDS.cmake

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-# Keep the same with https://github.com/NVIDIA/spark-rapids-jni/blob/main/src/branch-xx.xx/cpp/CMakeLists.txt
+# Keep the same with https://github.com/rapidsai/rapids-cmake/blob/branch-xx.yy/RAPIDS.cmake
 # the branch-xx.xx in the above line is the branch version
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -14,7 +14,8 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+set(rapids-cmake-version "25.06")
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-25.06/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -18,10 +18,10 @@
 # the branch-xx.xx in the above line is the branch version
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-# set to the cuDF version
+# set to the rapids-cmake version
 set(rapids-cmake-version "25.06")
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-25.06/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${rapids-cmake-version}/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 


### PR DESCRIPTION
closes #535

## Why error occurs
`https://github.com/rapidsai/rapids-cmake/blob/branch-25.06/RAPIDS.cmake` changed, it requires: rapids_cmake_version.

## solution
Just set the version.
For Every release, we MUST manually update the version of rapids_cmake_version.

Signed-off-by: Chong Gao <res_life@163.com>