### PR TITLE
Fix colab link for parquet microkernels notebook

### DIFF
--- a/examples/SQL+DF-Examples/demo/Spark_parquet_microkernels.ipynb
+++ b/examples/SQL+DF-Examples/demo/Spark_parquet_microkernels.ipynb
@@ -1,16 +1,6 @@
 {
   "cells": [
     {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "6GrElUvUhc7j"
-      },
-      "id": "6GrElUvUhc7j",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
       "cell_type": "markdown",
       "id": "Td_alkbOv3Aj",
       "metadata": {
@@ -28,7 +18,7 @@
         "id": "c6ed860b"
       },
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/rapidsai-community/showcase/blob/main/getting_started_tutorials/10min_to_cudf_colab.ipynb\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/NVIDIA/spark-rapids-examples/blob/main/examples/SQL%2BDF-Examples/demo/Spark_parquet_microkernels.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>\n"
       ]


### PR DESCRIPTION
Updated colab link from default (cudf 10m) to specific link for this notebook