### PR TITLE
Use cuda12 for UDF native example

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # A container that can be used to build UDF native code against libcudf
-ARG CUDA_VERSION=11.8.0
+ARG CUDA_VERSION=12.8.0
 ARG LINUX_VERSION=rockylinux8
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
@@ -50,7 +50,7 @@ RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/down
 ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
 
 # ccache for interactive builds
-ARG CCACHE_VERSION=4.6
+ARG CCACHE_VERSION=4.11.2
 RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
    tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
    rm ccache-${CCACHE_VERSION}.tar.gz && \

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <cuda.version>cuda11</cuda.version>
+        <cuda.version>cuda12</cuda.version>
         <scala.binary.version>2.12</scala.binary.version>
         <!-- Depends on release version, Snapshot version is not published to the Maven Central -->
         <rapids4spark.version>25.04.0</rapids4spark.version>

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
 # set to the rapids-cmake version
-set(rapids-cmake-version "25.06")
+set(rapids-cmake-version "25.08")
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${rapids-cmake-version}/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids-examples/issues/541

As rapids remove cuda11 support, we need to update testing against cuda12. 

This change has been verified internally 