### PR TITLE
Add edge.urm as the Maven repository to build UDF examples

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
@@ -233,4 +233,13 @@
             </build>
         </profile>
     </profiles>
+    <repositories>
+        <repository>
+            <id>urm</id>
+            <url>https://edge.urm.nvidia.com/artifactory/sw-spark-maven</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids-examples/issues/564

Since v25.08.0, we have started releasing rapids-4-spark plugin jars to edge.urm as the default Maven repository.

Therefore, we have updated the UDF examples to include the edge URM repository for fetching newly released plugins.