### PR TITLE
Fix udf build failed ci

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -90,11 +90,19 @@ set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
 
 rapids_cpm_init()
 
-# Pre-fetch spdlog to avoid deprecated rapids_cpm_spdlog usage
-rapids_cpm_find(spdlog 1.12.0
+# Pre-fetch fmt and spdlog to avoid deprecated rapids_cpm_spdlog usage
+rapids_cpm_find(fmt 11.0.2
+        CPM_ARGS
+        GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+        GIT_TAG         11.0.2
+        GIT_SHALLOW     TRUE
+        OPTIONS         "FMT_INSTALL OFF"
+)
+
+rapids_cpm_find(spdlog 1.14.1
         CPM_ARGS
         GIT_REPOSITORY  https://github.com/gabime/spdlog.git
-        GIT_TAG         v1.12.0
+        GIT_TAG         v1.14.1
         GIT_SHALLOW     TRUE
         OPTIONS         "SPDLOG_FMT_EXTERNAL ON"
                         "SPDLOG_BUILD_SHARED OFF"


### PR DESCRIPTION
This pr is to pre-fetch the fmt and spdlog dependencies with the correct versions and configuration options before cudf is loaded to fix a udf build issue. Already verified in local env.
 fix #579 

error:
```
[2025-09-25T07:42:40.162Z] [INFO]      [exec] -- CPM: Adding package rapids_logger@0.1.0 (46070bb255482f0782ca840ae45de9354380e298)
[2025-09-25T07:42:40.162Z] [INFO]      [exec] CMake Error at /home/jenkins/agent/workspace/jenkins-examples-udf-examples-native-435/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/cpp-build/_deps/rapids-cmake-src/rapids-cmake/cmake/detail/policy.cmake:55 (message):
[2025-09-25T07:42:40.162Z] [INFO]      [exec]   rapids-cmake policy [deprecated=25.08 removed=25.12]: `rapids_cpm_spdlog`
[2025-09-25T07:42:40.162Z] [INFO]      [exec]   is deprecated.  If you need to fetch spdlog, please use rapids_cpm_find
[2025-09-25T07:42:40.162Z] [INFO]      [exec]   directly.
[2025-09-25T07:42:40.162Z] [INFO]      [exec] Call Stack (most recent call first):
[2025-09-25T07:42:40.162Z] [INFO]      [exec]   /home/jenkins/agent/workspace/jenkins-examples-udf-examples-native-435/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/cpp-build/_deps/rapids-cmake-src/rapids-cmake/cpm/spdlog.cmake:72 (rapids_cmake_policy)
[2025-09-25T07:42:40.162Z] [INFO]      [exec]   /home/jenkins/agent/workspace/jenkins-examples-udf-examples-native-435/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/cpp-build/_deps/rapids_logger-src/CMakeLists.txt:83 (rapids_cpm_spdlog)
```

after apply the patch
```
/maven/shared/maven-common-artifact-filters/1.4/maven-common-artifact-filters-1.4.jar (32 kB at 86 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/2.0.11/maven-invoker-2.0.11.jar (29 kB at 71 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar (575 kB at 1.3 MB/s)
[INFO] Configured Artifact: com.nvidia:rapids-4-spark_2.12:25.08.0:jar
[INFO] Copying rapids-4-spark_2.12-25.08.0.jar to /root/spark-rapids-examples/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/dependency/rapids-4-spark_2.12-25.08.0.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:16 h
[INFO] Finished at: 2025-09-26T08:43:20Z
[INFO] ----------------------------------------
```

