### PR TITLE
Update automerge pattern to release/* [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-      - branch-*
+      - release/*
     types: [closed]
 
 jobs:


### PR DESCRIPTION
New: `release/* -> main`

The automerge will be working only in burndown&code freeze phase now