### PR TITLE
Change the plugin jars linkage back to Maven Central Repo

### DIFF
--- a/examples/ML+DL-Examples/Optuna-Spark/optuna-examples/optuna-dataframe.ipynb
+++ b/examples/ML+DL-Examples/Optuna-Spark/optuna-examples/optuna-dataframe.ipynb
@@ -455,7 +455,7 @@
     "    rapids_jar = f\"rapids-4-spark_2.12-{SPARK_RAPIDS_VERSION}.jar\"\n",
     "    if not os.path.exists(rapids_jar):\n",
     "        print(\"Downloading Spark Rapids jar\")\n",
-    "        url = f\"https://edge.urm.nvidia.com/artifactory/sw-spark-maven/com/nvidia/rapids-4-spark_2.12/{SPARK_RAPIDS_VERSION}/{rapids_jar}\"\n",
+    "        url = f\"https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/{SPARK_RAPIDS_VERSION}/{rapids_jar}\"\n",
     "        response = requests.get(url)\n",
     "        if response.status_code == 200:\n",
     "            with open(rapids_jar, \"wb\") as f:\n",

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
@@ -236,7 +236,7 @@
     <repositories>
         <repository>
             <id>urm</id>
-            <url>https://edge.urm.nvidia.com/artifactory/sw-spark-maven</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/examples/spark-connect-gpu/README.md
+++ b/examples/spark-connect-gpu/README.md
@@ -262,7 +262,7 @@ and a 2x8-core CPU
 
 ### Spark Connect Server
 - **Image**: Custom build based on `apache/spark:4.0.0` with Spark RAPIDS ETL and ML Plugins
-- **RAPIDS Version**: 25.08.0 for CUDA 12
+- **RAPIDS Version**: 25.10.0 for CUDA 12
 - **Ports**: 15002 (gRPC), 4040 (Driver UI)
 - **Configuration**: Optimized for GPU acceleration with memory management
 

--- a/examples/spark-connect-gpu/docker-compose.yaml
+++ b/examples/spark-connect-gpu/docker-compose.yaml
@@ -74,8 +74,8 @@ services:
       dockerfile: Dockerfile
       args:
         - CUDA_VERSION=${CUDA_VERSION:-12}
-        - RAPIDS_VERSION=${RAPIDS_VERSION:-25.08.0}
-        - REPO_URL=${REPO_URL:-https://edge.urm.nvidia.com/artifactory/sw-spark-maven}
+        - RAPIDS_VERSION=${RAPIDS_VERSION:-25.10.0}
+        - REPO_URL=${REPO_URL:-https://repo1.maven.org/maven2}
     container_name: spark-connect-server
     hostname: spark-connect-server
     environment:


### PR DESCRIPTION
Due to the Central Sonatype bundle size limitation (less than 2 GB), we changed the release destination for the plugin JARs to edge.urm Maven repository starting from v25.08.0(https://edge.urm.nvidia.com/artifactory/sw-spark-maven-local/com/nvidia/rapids-4-spark_2.12/25.08.0/).

Now that Central Sonatype has resolved the bundle size limitation, we have switched back to releasing the plugin JARs to the Maven Central repository starting with the v25.10.0(https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/25.10.0/) release.