### PR TITLE
Fix native UDF toolchain alignment for cuDF main

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ ARG LINUX_VERSION=rockylinux8
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
 
-ARG TOOLSET_VERSION=14
-ENV TOOLSET_VERSION=14
+ARG TOOLSET_VERSION=13
+ENV TOOLSET_VERSION=13
 ARG PARALLEL_LEVEL=10
 ENV PARALLEL_LEVEL=10
 

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
 # set to the rapids-cmake-branch
-set(rapids-cmake-branch "release/26.02")
+set(rapids-cmake-branch "main")
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/${rapids-cmake-branch}/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)


### PR DESCRIPTION
Fixes #623.

## Summary

The native UDF build should stay on cuDF `main`. The failure was caused by toolchain/dependency mismatch with the `libcudf.so` used at runtime.

This PR:
- updates RAPIDS CMake from `release/26.02` to `main`
- changes the native UDF Docker default from `gcc-toolset-14` to `gcc-toolset-13`
 