### PR TITLE
Update CMake to 4.0

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/Dockerfile
@@ -41,7 +41,7 @@ RUN dnf --enablerepo=powertools install -y \
   && alternatives --set python /usr/bin/python3
 
 # 3.22.3: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
-ARG CMAKE_VERSION=3.30.4
+ARG CMAKE_VERSION=4.0.3
 # default x86_64 from x86 build, aarch64 cmake for arm build
 ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/src/main/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@
 #=============================================================================
 
 # Keep the same with https://github.com/rapidsai/rapids-cmake/blob/main/RAPIDS.cmake
-cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
 
 # set to the rapids-cmake-branch
 set(rapids-cmake-branch "main")


### PR DESCRIPTION
To fix build cuDF cmake version error

```
[INFO]      [exec] CMake Error at /home/jenkins/agent/workspace/jenkins-examples-udf-examples-native-597/examples/UDF-Examples/RAPIDS-accelerated-UDFs/target/cpp-build/_deps/cudf-src/cpp/CMakeLists.txt:8 (cmake_minimum_required):
[INFO]      [exec]   CMake 4.0 or higher is required.  You are running version 3.30.4
```

Refer to https://github.com/NVIDIA/spark-rapids-jni/pull/4557

This commit updates CMakeLists.txt to use CMake 4.0+, and updates the Dockerfile used in the build.

This is in line with the changes in cuDF, in rapidsai/cudf#22492.